### PR TITLE
linux-dpdk: pool: Return address range in pool info

### DIFF
--- a/platform/linux-dpdk/odp_pool.c
+++ b/platform/linux-dpdk/odp_pool.c
@@ -613,6 +613,7 @@ void odp_pool_print(odp_pool_t pool_hdl)
 int odp_pool_info(odp_pool_t pool_hdl, odp_pool_info_t *info)
 {
 	pool_t *pool = pool_entry_from_hdl(pool_hdl);
+	struct rte_mempool_memhdr *hdr;
 
 	if (pool == NULL || info == NULL)
 		return -1;
@@ -622,6 +623,10 @@ int odp_pool_info(odp_pool_t pool_hdl, odp_pool_info_t *info)
 
 	if (pool->params.type == ODP_POOL_PACKET)
 		info->pkt.max_num = pool->rte_mempool->size;
+
+	hdr = STAILQ_FIRST(&pool->rte_mempool->mem_list);
+	info->min_data_addr = (uintptr_t)hdr->addr;
+	info->max_data_addr = (uintptr_t)hdr->addr + hdr->len - 1;
 
 	return 0;
 }


### PR DESCRIPTION
Implement support in odp_pool_info function to provide
address range of pool data available for application.

Similar change was already merged to caterpillar/linux-dpdk:
https://github.com/Linaro/odp/pull/400

Pull request of related API change:
https://github.com/Linaro/odp/pull/200

