### PR TITLE
Add checksum support to linux-dpdk/dpdk pktio

### DIFF
--- a/platform/linux-dpdk/include/odp_packet_dpdk.h
+++ b/platform/linux-dpdk/include/odp_packet_dpdk.h
@@ -39,6 +39,10 @@
 #include <rte_random.h>
 #include <rte_ether.h>
 #include <rte_ethdev.h>
+#include <rte_ip.h>
+#include <rte_ip_frag.h>
+#include <rte_udp.h>
+#include <rte_tcp.h>
 #include <rte_hash.h>
 #include <rte_jhash.h>
 #include <rte_hash_crc.h>

--- a/platform/linux-dpdk/odp_packet_dpdk.c
+++ b/platform/linux-dpdk/odp_packet_dpdk.c
@@ -254,6 +254,21 @@ static int dpdk_init_capability(pktio_entry_t *pktio_entry,
 	if (capa->config.pktin.bit.tcp_chksum)
 		capa->config.pktin.bit.drop_tcp_err = 1;
 
+	/* CSUM TX capabilities*/
+	capa->config.pktout.bit.ipv4_chksum =
+		(dev_info->tx_offload_capa & DEV_TX_OFFLOAD_IPV4_CKSUM) ? 1 : 0;
+	capa->config.pktout.bit.udp_chksum =
+		(dev_info->tx_offload_capa & DEV_TX_OFFLOAD_UDP_CKSUM) ? 1 : 0;
+	capa->config.pktout.bit.tcp_chksum =
+		(dev_info->tx_offload_capa & DEV_TX_OFFLOAD_TCP_CKSUM) ? 1 : 0;
+
+	capa->config.pktout.bit.ipv4_chksum_ena =
+		capa->config.pktout.bit.ipv4_chksum;
+	capa->config.pktout.bit.udp_chksum_ena =
+		capa->config.pktout.bit.udp_chksum;
+	capa->config.pktout.bit.tcp_chksum_ena =
+		capa->config.pktout.bit.tcp_chksum;
+
 	return 0;
 }
 
@@ -390,10 +405,51 @@ static int start_pkt_dpdk(pktio_entry_t *pktio_entry)
 		}
 	}
 
+	pktio_entry->s.chksum_insert_ena = 0;
+
 	/* init one TX queue on each port */
 	for (i = 0; i < nbtxq; i++) {
+		struct rte_eth_dev_info dev_info;
+		const struct rte_eth_txconf *txconf = NULL;
+		int ip_ena  = pktio_entry->s.config.pktout.bit.ipv4_chksum_ena;
+		int udp_ena = pktio_entry->s.config.pktout.bit.udp_chksum_ena;
+		int tcp_ena = pktio_entry->s.config.pktout.bit.tcp_chksum_ena;
+		int sctp_ena = pktio_entry->s.config.pktout.bit.sctp_chksum_ena;
+		int chksum_ena = ip_ena | udp_ena | tcp_ena | sctp_ena;
+
+		if (chksum_ena) {
+			/* Enable UDP, TCP, STCP checksum offload */
+			uint32_t txq_flags = 0;
+
+			if (udp_ena == 0)
+				txq_flags |= ETH_TXQ_FLAGS_NOXSUMUDP;
+
+			if (tcp_ena == 0)
+				txq_flags |= ETH_TXQ_FLAGS_NOXSUMTCP;
+
+			if (sctp_ena == 0)
+				txq_flags |= ETH_TXQ_FLAGS_NOXSUMSCTP;
+
+			/* When IP checksum is requested alone, enable UDP
+			 * offload. DPDK IP checksum offload is enabled only
+			 * when one of the L4 checksum offloads is requested.*/
+			if ((udp_ena == 0) && (tcp_ena == 0) && (sctp_ena == 0))
+				txq_flags = ETH_TXQ_FLAGS_NOXSUMTCP |
+					    ETH_TXQ_FLAGS_NOXSUMSCTP;
+
+			txq_flags |= ETH_TXQ_FLAGS_NOMULTSEGS |
+				     ETH_TXQ_FLAGS_NOREFCOUNT |
+				     ETH_TXQ_FLAGS_NOMULTMEMP |
+				     ETH_TXQ_FLAGS_NOVLANOFFL;
+
+			rte_eth_dev_info_get(port_id, &dev_info);
+			dev_info.default_txconf.txq_flags = txq_flags;
+			txconf = &dev_info.default_txconf;
+			pktio_entry->s.chksum_insert_ena = 1;
+		}
+
 		ret = rte_eth_tx_queue_setup(port_id, i, nb_txd, socket_id,
-					     NULL);
+					     txconf);
 		if (ret < 0) {
 			ODP_ERR("txq:err=%d, port=%" PRIu16 "\n", ret, port_id);
 			return -1;
@@ -659,10 +715,123 @@ static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 	return nb_rx;
 }
 
+static inline int check_proto(void *l3_hdr, odp_bool_t *l3_proto_v4,
+			      uint8_t *l4_proto)
+{
+	uint8_t l3_proto_ver = _ODP_IPV4HDR_VER(*(uint8_t *)l3_hdr);
+
+	if (l3_proto_ver == _ODP_IPV4) {
+		struct ipv4_hdr *ip = (struct ipv4_hdr *)l3_hdr;
+
+		*l3_proto_v4 = 1;
+		if (!rte_ipv4_frag_pkt_is_fragmented(ip))
+			*l4_proto = ip->next_proto_id;
+		else
+			*l4_proto = 0;
+
+		return 0;
+	} else if (l3_proto_ver == _ODP_IPV6) {
+		struct ipv6_hdr *ipv6 = (struct ipv6_hdr *)l3_hdr;
+
+		*l3_proto_v4 = 0;
+		*l4_proto = ipv6->proto;
+		return 0;
+	}
+
+	return -1;
+}
+
+static inline uint16_t phdr_csum(odp_bool_t ipv4, void *l3_hdr,
+				 uint64_t ol_flags)
+{
+	if (ipv4)
+		return rte_ipv4_phdr_cksum(l3_hdr, ol_flags);
+	else /*ipv6*/
+		return rte_ipv6_phdr_cksum(l3_hdr, ol_flags);
+}
+
+#define OL_TX_CHKSUM_PKT(_cfg, _capa, _proto, _ovr_set, _ovr) \
+	(_capa && _proto && (_ovr_set ? _ovr : _cfg))
+
+static inline void pkt_set_ol_tx(odp_pktout_config_opt_t *pktout_cfg,
+				 odp_pktout_config_opt_t *pktout_capa,
+				 odp_packet_hdr_t *pkt_hdr,
+				 struct rte_mbuf *mbuf,
+				 char *mbuf_data)
+{
+	void *l3_hdr, *l4_hdr;
+	uint8_t l4_proto;
+	odp_bool_t l3_proto_v4;
+	odp_bool_t ipv4_chksum_pkt, udp_chksum_pkt, tcp_chksum_pkt;
+	packet_parser_t *pkt_p = &pkt_hdr->p;
+
+	if (pkt_p->l3_offset == ODP_PACKET_OFFSET_INVALID)
+		return;
+
+	l3_hdr = (void *)(mbuf_data + pkt_p->l3_offset);
+
+	if (check_proto(l3_hdr, &l3_proto_v4, &l4_proto))
+		return;
+
+	ipv4_chksum_pkt = OL_TX_CHKSUM_PKT(pktout_cfg->bit.ipv4_chksum,
+					   pktout_capa->bit.ipv4_chksum,
+					   l3_proto_v4,
+					   pkt_p->output_flags.l3_chksum_set,
+					   pkt_p->output_flags.l3_chksum);
+	udp_chksum_pkt =  OL_TX_CHKSUM_PKT(pktout_cfg->bit.udp_chksum,
+					   pktout_capa->bit.udp_chksum,
+					   (l4_proto == _ODP_IPPROTO_UDP),
+					   pkt_p->output_flags.l4_chksum_set,
+					   pkt_p->output_flags.l4_chksum);
+	tcp_chksum_pkt =  OL_TX_CHKSUM_PKT(pktout_cfg->bit.tcp_chksum,
+					   pktout_capa->bit.tcp_chksum,
+					   (l4_proto == _ODP_IPPROTO_TCP),
+					   pkt_p->output_flags.l4_chksum_set,
+					   pkt_p->output_flags.l4_chksum);
+
+	if (!ipv4_chksum_pkt && !udp_chksum_pkt && !tcp_chksum_pkt)
+		return;
+
+	if (pkt_p->l4_offset == ODP_PACKET_OFFSET_INVALID)
+		return;
+
+	mbuf->l2_len = pkt_p->l3_offset - pkt_p->l2_offset;
+	mbuf->l3_len = pkt_p->l4_offset - pkt_p->l3_offset;
+
+	if (l3_proto_v4)
+		mbuf->ol_flags = PKT_TX_IPV4;
+	else
+		mbuf->ol_flags = PKT_TX_IPV6;
+
+	if (ipv4_chksum_pkt) {
+		mbuf->ol_flags |=  PKT_TX_IP_CKSUM;
+
+		((struct ipv4_hdr *)l3_hdr)->hdr_checksum = 0;
+	}
+
+	l4_hdr = (void *)(mbuf_data + pkt_p->l4_offset);
+
+	if (udp_chksum_pkt) {
+		mbuf->ol_flags |= PKT_TX_UDP_CKSUM;
+
+		((struct udp_hdr *)l4_hdr)->dgram_cksum =
+			phdr_csum(l3_proto_v4, l3_hdr, mbuf->ol_flags);
+	} else if (tcp_chksum_pkt) {
+		mbuf->ol_flags |= PKT_TX_TCP_CKSUM;
+
+		((struct tcp_hdr *)l4_hdr)->cksum =
+			phdr_csum(l3_proto_v4, l3_hdr, mbuf->ol_flags);
+	}
+}
+
 static int send_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 			 const odp_packet_t pkt_table[], int len)
 {
 	pkt_dpdk_t * const pkt_dpdk = &pktio_entry->s.pkt_dpdk;
+	uint8_t chksum_insert_ena = pktio_entry->s.chksum_insert_ena;
+	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->s.config.pktout;
+	odp_pktout_config_opt_t *pktout_capa =
+		&pktio_entry->s.capa.config.pktout;
 	int pkts;
 	int i;
 	uint32_t mtu = pkt_dpdk->mtu;
@@ -673,6 +842,13 @@ static int send_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 
 		if (odp_unlikely(mbuf->pkt_len > mtu))
 			break;
+
+		mbuf->ol_flags = 0;
+		if (chksum_insert_ena)
+			pkt_set_ol_tx(pktout_cfg, pktout_capa,
+				      odp_packet_hdr(pkt_table[i]), mbuf,
+				      rte_pktmbuf_mtod(mbuf, char *));
+
 		num_tx++;
 	}
 


### PR DESCRIPTION
Add checksum support to linux-dpdk/dpdk pktio.

Much of the code is copied from linux-generic/dpdk pktio. If needed we can further refine the PR to reduce code duplication.