### PR TITLE
README.DPDK: updated

### DIFF
--- a/platform/linux-dpdk/README
+++ b/platform/linux-dpdk/README
@@ -37,12 +37,8 @@ Prerequisites and considerations:
 
 Fetching the DPDK code:
 ----------------------
-    git clone http://dpdk.org/git/dpdk ./<dpdk-dir>
-
 Right now odp-dpdk only supports DPDK v17.08:
-    cd <dpdk-dir>
-    git tag -l -- will list all the tags available
-    git checkout -b 17.08 tags/v17.08
+    git clone http://dpdk.org/git/dpdk-stable --branch 17.08 --depth 1 ./<dpdk-dir>
 
 Compile DPDK:
 ------------
@@ -67,7 +63,8 @@ Enable openssl crypto pmd to use openssl with odp-dpdk:
 Now return to parent directory and build DPDK:
     cd ..
 
-The last step depends on if shared libraries are required.
+The last step depends on whether ODP shared libraries will be built with this
+deployment of DPDK:
 SHARED libraries:
     make install T=x86_64-native-linuxapp-gcc DESTDIR=./install EXTRA_CFLAGS="-fPIC"
 
@@ -86,8 +83,8 @@ path with the --with-dpdk-path option.
     cd <odp-dir>
     ./bootstrap
 
-The following step depends on if shared libraries are required.
-SHARED libraries:
+The following step depends on whether ODP shared libraries are to be built.
+SHARED libraries (requires building DPDK with -fPIC, see above):
     ./configure --with-dpdk-path=<dpdk-dir>/x86_64-native-linuxapp-gcc
 
 STATIC libraries (better performance):
@@ -235,38 +232,7 @@ CONFIG_RTE_LIBRTE_PMD_PCAP=y
 Finally give l2fwd fake devices:
     ./l2fwd -c '0xf' -n 4 --vdev "eth_pcap0,iface=veth2-1" --vdev="eth_pcap1,iface=veth2-3" -- -p 3
 
-7. Build with devbuild.sh
-=================================================
-
-scripts/devbuild.sh contains an example script aimed for developers. It uses
-the CI scripts from https://git.linaro.org/lng/check-odp.git to build DPDK and
-ODP-DPDK. It can also run "make check" or individual unit tests, but you need to
-install CUnit as a prerequisite.
-If you have build problems, try to run it and see if it works. An example:
-	export REPOS=${PWD}
-	git clone https://git.linaro.org/lng/check-odp.git
-	git clone https://git.linaro.org/lng/odp-dpdk.git
-	odp-dpdk/scripts/devbuild.sh dpdk
-	odp-dpdk/scripts/devbuild.sh odp
-	odp-dpdk/scripts/devbuild.sh odp-check
-
-It can also run unit tests individually, optionally with gdb. If the first
-parameter is not dpdk, odp or odp-check, it tries to run it in
-"$CHECK_ODP_DIR/new-build/bin/", with the help of the wrapper script. That's
-where example programs are, but you can also use it to run the unit tests, by
-traversing the directories:
-
-	odp-dpdk/scripts/devbuild.sh \
-	../../../odp-dpdk/test/common_plat/validation/api/atomic/atomic_main
-	odp-dpdk/scripts/devbuild.sh \
-	../../../odp-dpdk/test/linux-dpdk/validation/api/pktio/pktio_run.sh
-
-The wrapper will prepend the executable with ODP_GDB env. variable, or pass it
-down if its name ends ".sh". With prepending your command line with ODP_GDB=gdb
-you can run the tests in GDB. If the unit test is wrapped into yet another
-shell script (like pktio), it has to do the prepending itself!
-
-8. Upgrading ODP-DPDK to newer ODP API level
+7. Upgrading ODP-DPDK to newer ODP API level
 =================================================
 
 This repository is based on odp.git, it also retains the history of that. There
@@ -275,7 +241,7 @@ changes are in platform/linux-dpdk. That directory's Makefile.am builds our
 code and the required parts from platform/linux-generic.
 This allows us to easily pull the necessary changes from odp.git with git:
 
-git remote add odp_base https://git.linaro.org/lng/odp.git
+git remote add odp_base https://github.com/Linaro/odp.git
 git pull odp_base master
 
 This will result in a merge commit, and possibly some conflict resolving if
@@ -291,7 +257,7 @@ scripts/git-transplant.py platform/linux-generic/ platform/linux-dpdk/ \
 It prints the list of prospective patches to be ported. See its comments about
 what it does.
 
-9. Building odp-dpdk with dpdk crypto PMD's
+8. Building odp-dpdk with dpdk crypto PMD's
 ======================================================
 
 Refer to dpdk crypto documentation for detailed building of crypto PMD's:


### PR DESCRIPTION
Referece Linaro's github repository instead of the one hosted at Linaro.

Use dpdk-stable git repo for DPDK, simplify cloning instructions, and
clarify when to build DPDK with -fPIC flag.

Remove section referencing devbuild.sh, as check-odp it is not maintained
anymore.

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>