### PR TITLE
travis: allow to fail checkpatch.pl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -209,6 +209,7 @@ jobs:
                             --with-dpdk-path=`pwd`/dpdk/${TARGET}
                           - make -j $(nproc)
                 - stage: test
+                  canfail: yes
                   env: TEST=checkpatch
                   compiler: gcc
                   install:
@@ -217,6 +218,8 @@ jobs:
                           - echo ${TRAVIS_COMMIT_RANGE};
                           - ODP_PATCHES=`echo ${TRAVIS_COMMIT_RANGE} | sed 's/\.//'`;
                           - ./scripts/ci-checkpatches.sh ${ODP_PATCHES};
+        allow_failures:
+          - canfail: yes
 
 after_failure:
   - cat config.log


### PR DESCRIPTION
backport of 84c37a0f: travis: allow to fail checkpatch.pl
from linux-generic

if checkpatch job is failed than it will be marked as failed.
But hole test suite will be passed.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
Reviewed-by: Bill Fischofer <bill.fischofer@linaro.org>
Reviewed-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>