### PR TITLE
[PATCH v1] linux-dpdk: major rewrite of crypto module

### DIFF
--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -10,6 +10,12 @@ AS_VAR_APPEND([DPDK_PMDS], [-l$cur_driver,])
 AS_CASE([$cur_driver],
     [rte_pmd_nfp], [AS_VAR_APPEND([DPDK_LIBS], [" -lm"])],
     [rte_pmd_pcap], [AS_VAR_APPEND([DPDK_LIBS], [" -lpcap"])],
+    [rte_pmd_aesni_gcm], [AS_VAR_APPEND([DPDK_LIBS], [" -lIPSec_MB"])],
+    [rte_pmd_aesni_mb], [AS_VAR_APPEND([DPDK_LIBS], [" -lIPSec_MB"])],
+    [rte_pmd_kasumi], [AS_VAR_APPEND([DPDK_LIBS], [" -lsso_kasumi"])],
+    [rte_pmd_snow3g], [AS_VAR_APPEND([DPDK_LIBS], [" -lsso_snow3g"])],
+    [rte_pmd_zuc], [AS_VAR_APPEND([DPDK_LIBS], [" -lsso_zuc"])],
+    [rte_pmd_qat], [AS_VAR_APPEND([DPDK_LIBS], [" -lcrypto"])],
     [rte_pmd_openssl], [AS_VAR_APPEND([DPDK_LIBS], [" -lcrypto"])])
 done
 AS_VAR_APPEND([DPDK_PMDS], [--no-whole-archive])

--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -142,7 +142,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   ../linux-generic/odp_cpu.c \
 			   ../linux-generic/odp_cpumask.c \
 			   ../linux-generic/odp_cpumask_task.c \
-			   ../linux-generic/odp_crypto.c \
+			   odp_crypto.c \
 			   odp_errno.c \
 			   ../linux-generic/odp_event.c \
 			   ../linux-generic/odp_hash.c \

--- a/platform/linux-dpdk/include/odp_packet_internal.h
+++ b/platform/linux-dpdk/include/odp_packet_internal.h
@@ -125,6 +125,10 @@ typedef struct {
 #define PACKET_DIGEST_MAX 64
 	uint8_t crypto_digest_buf[PACKET_DIGEST_MAX];
 
+	/* Temp storage for AAD */
+#define PACKET_AAD_MAX 32
+	uint8_t crypto_aad_buf[PACKET_AAD_MAX];
+
 	/* Context for IPsec */
 	odp_ipsec_packet_result_t ipsec_ctx;
 

--- a/platform/linux-dpdk/include/odp_packet_internal.h
+++ b/platform/linux-dpdk/include/odp_packet_internal.h
@@ -121,6 +121,10 @@ typedef struct {
 	/* Result for crypto packet op */
 	odp_crypto_packet_result_t crypto_op_result;
 
+	/* Temp storage for digest */
+#define PACKET_DIGEST_MAX 64
+	uint8_t crypto_digest_buf[PACKET_DIGEST_MAX];
+
 	/* Context for IPsec */
 	odp_ipsec_packet_result_t ipsec_ctx;
 

--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -505,10 +505,13 @@ static void capability_process(struct rte_cryptodev_info *dev_info,
 				auths->bit.aes128_gcm = 1;
 #endif
 			}
+			/* AES-CCM algorithm produces errors in Ubuntu Trusty,
+			 * so it is disabled for now
 			if (cap_aead_algo == RTE_CRYPTO_AEAD_AES_CCM) {
 				ciphers->bit.aes_ccm = 1;
 				auths->bit.aes_ccm = 1;
 			}
+			*/
 		}
 	}
 }

--- a/platform/linux-dpdk/test/wrapper-script.sh
+++ b/platform/linux-dpdk/test/wrapper-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:--n 4 --vdev "crypto_openssl"}
+export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:--n 4 --vdev "crypto_openssl" --vdev crypto_null}
 # where to mount huge pages
 export HUGEPAGEDIR=${HUGEPAGEDIR:-/mnt/huge}
 # exit codes expected by automake for skipped tests

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -51,6 +51,30 @@ static uint8_t test_key24[24] = { 0x01, 0x02, 0x03, 0x04, 0x05,
 				  0x15, 0x16, 0x17, 0x18
 };
 
+static uint8_t test_key32[32] = { 0x01, 0x02, 0x03, 0x04, 0x05,
+				  0x06, 0x07, 0x08, 0x09, 0x0a,
+				  0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+				  0x10, 0x11, 0x12, 0x13, 0x14,
+				  0x15, 0x16, 0x17, 0x18, 0x19,
+				  0x1a, 0x1b, 0x1c, 0x1d, 0x1e,
+				  0x1f, 0x20,
+};
+
+static uint8_t test_key64[64] = { 0x01, 0x02, 0x03, 0x04, 0x05,
+				  0x06, 0x07, 0x08, 0x09, 0x0a,
+				  0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+				  0x10, 0x11, 0x12, 0x13, 0x14,
+				  0x15, 0x16, 0x17, 0x18, 0x19,
+				  0x1a, 0x1b, 0x1c, 0x1d, 0x1e,
+				  0x1f, 0x20, 0x21, 0x22, 0x23,
+				  0x24, 0x25, 0x26, 0x27, 0x28,
+				  0x29, 0x2a, 0x4b, 0x2c, 0x2d,
+				  0x2e, 0x2f, 0x30, 0x31, 0x32,
+				  0x33, 0x34, 0x55, 0x36, 0x37,
+				  0x38, 0x39, 0x5a, 0x3b, 0x3c,
+				  0x3d, 0x3e, 0x5f, 0x40,
+};
+
 /**
  * Structure that holds template for session create call
  * for different algorithms supported by test
@@ -280,6 +304,81 @@ static crypto_alg_config_t algs_config[] = {
 		},
 	},
 	{
+		.name = "aes-ctr-null",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_AES_CTR,
+			.cipher_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.cipher_iv = {
+				.data = test_iv,
+				.length = 16,
+			},
+			.auth_alg = ODP_AUTH_ALG_NULL
+		},
+	},
+	{
+		.name = "aes-ctr-hmac-sha1-96",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_AES_CTR,
+			.cipher_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.cipher_iv = {
+				.data = test_iv,
+				.length = 16,
+			},
+			.auth_alg = ODP_AUTH_ALG_SHA1_HMAC,
+			.auth_key = {
+				.data = test_key20,
+				.length = sizeof(test_key20)
+			},
+			.auth_digest_len = 12,
+		},
+	},
+	{
+		.name = "null-hmac-sha256-128",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_NULL,
+			.auth_alg = ODP_AUTH_ALG_SHA256_HMAC,
+			.auth_key = {
+				.data = test_key32,
+				.length = sizeof(test_key32)
+			},
+			.auth_digest_len = 16,
+		},
+	},
+	{
+		.name = "null-hmac-sha512-256",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_NULL,
+			.auth_alg = ODP_AUTH_ALG_SHA512_HMAC,
+			.auth_key = {
+				.data = test_key64,
+				.length = sizeof(test_key64)
+			},
+			.auth_digest_len = 32,
+		},
+	},
+	{
+		.name = "null-aes-gmac",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_NULL,
+			.auth_alg = ODP_AUTH_ALG_AES_GMAC,
+			.auth_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.auth_iv = {
+				.data = test_iv,
+				.length = 12,
+			},
+			.auth_digest_len = 16,
+		},
+	},
+	{
 		.name = "aes-gcm",
 		.session = {
 			.cipher_alg = ODP_CIPHER_ALG_AES_GCM,
@@ -292,6 +391,38 @@ static crypto_alg_config_t algs_config[] = {
 				.length = 12,
 			},
 			.auth_alg = ODP_AUTH_ALG_AES_GCM,
+			.auth_digest_len = 16,
+		},
+	},
+	{
+		.name = "aes-ccm",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_AES_CCM,
+			.cipher_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.cipher_iv = {
+				.data = test_iv,
+				.length = 11,
+			},
+			.auth_alg = ODP_AUTH_ALG_AES_CCM,
+			.auth_digest_len = 16,
+		},
+	},
+	{
+		.name = "chacha20-poly1305",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_CHACHA20_POLY1305,
+			.cipher_key = {
+				.data = test_key32,
+				.length = sizeof(test_key32)
+			},
+			.cipher_iv = {
+				.data = test_iv,
+				.length = 12,
+			},
+			.auth_alg = ODP_AUTH_ALG_CHACHA20_POLY1305,
 			.auth_digest_len = 16,
 		},
 	},

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -75,6 +75,8 @@ static const char *cipher_alg_name(odp_cipher_alg_t cipher)
 		return "ODP_CIPHER_ALG_3DES_CBC";
 	case ODP_CIPHER_ALG_AES_CBC:
 		return "ODP_CIPHER_ALG_AES_CBC";
+	case ODP_CIPHER_ALG_AES_CTR:
+		return "ODP_CIPHER_ALG_AES_CTR";
 	case ODP_CIPHER_ALG_AES_GCM:
 		return "ODP_CIPHER_ALG_AES_GCM";
 	case ODP_CIPHER_ALG_AES_CCM:

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -196,7 +196,7 @@ static int alg_packet_op(odp_packet_t pkt,
 	op_params.hash_result_offset = plaintext_len;
 
 	rc = odp_crypto_op(&pkt, &out_pkt, &op_params, 1);
-	if (rc < 0) {
+	if (rc <= 0) {
 		CU_FAIL("Failed odp_crypto_packet_op()");
 		return rc;
 	}
@@ -257,7 +257,7 @@ static int alg_packet_op_enq(odp_packet_t pkt,
 	op_params.hash_result_offset = plaintext_len;
 
 	rc = odp_crypto_op_enq(&pkt, &pkt, &op_params, 1);
-	if (rc < 0) {
+	if (rc <= 0) {
 		CU_FAIL("Failed odp_crypto_op_enq()");
 		return rc;
 	}


### PR DESCRIPTION
Rewrite crypto module, simplifying operations, making them actually
work.

TODO before merging:

- [x] AEAD support
- [x] store IV data in session, rather than just pointers
- [x] physical address of digest in case it lies in control data (or find a way to move it to mbuf data)


Future plans:
- [ ] proper ASYNC support (might require changes to scheduler).
- [ ] use in-packet place for digest calculation if possible.
- [x] CCM implementation