### PR TITLE
[PATCH v3] RFC: implement scheduler and queues using DPDK eventdev

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.0.1"
+config_file_version = "0.0.2"
 
 # DPDK pktio options
 pktio_dpdk: {
@@ -46,4 +46,19 @@ sched_basic: {
 	# uneven service level for low thread counts. Typically, optimal
 	# value is the number of threads using the scheduler.
 	prio_spread = 4
+}
+
+sched_eventdev: {
+	# Eventdev supports up to RTE_EVENT_MAX_QUEUES_PER_DEV queues and these
+	# have to be mapped to ODP's scheduled queue types at startup. If the
+	# combined number of queues is zero, eventdev queues are divined evenly
+	# to ODP queue types.
+	num_atomic_queues = 0
+	num_ordered_queues = 0
+	num_parallel_queues = 0
+
+	# Number of event ports (zero = all available). Each ODP worker
+	# calling scheduler or doing queue enqueue requires a private event
+	# port.
+	num_ports = 0
 }

--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -93,6 +93,7 @@ noinst_HEADERS = \
 		  ${top_srcdir}/platform/linux-generic/include/odp_classification_datamodel.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_classification_inlines.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_classification_internal.h \
+		  include/odp_eventdev_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_forward_typedefs_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_ipsec_internal.h \
@@ -163,12 +164,14 @@ __LIB__libodp_linux_la_SOURCES = \
 			   ../linux-generic/odp_pkt_queue.c \
 			   odp_pool.c \
 			   odp_queue_basic.c \
+			   odp_queue_eventdev.c \
 			   odp_queue_if.c \
 			   ../linux-generic/odp_queue_lf.c \
 			   ../linux-generic/odp_random.c \
 			   ../linux-generic/odp_rwlock.c \
 			   ../linux-generic/odp_rwlock_recursive.c \
 			   ../linux-generic/odp_schedule_basic.c \
+			   odp_schedule_eventdev.c \
 			   odp_schedule_if.c \
 			   ../linux-generic/odp_schedule_sp.c \
 			   ../linux-generic/odp_schedule_iquery.c \

--- a/platform/linux-dpdk/README
+++ b/platform/linux-dpdk/README
@@ -57,6 +57,9 @@ Enable pcap pmd to use ODP-DPDK without DPDK supported NIC's:
 Enable openssl crypto pmd to use openssl with odp-dpdk:
     sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config
 
+Add more queues to eventdev
+    sed -ri 's,(CONFIG_RTE_EVENT_MAX_QUEUES_PER_DEV=).*,\1255,' .config
+
 Now return to parent directory and build DPDK:
     cd ..
 
@@ -254,7 +257,7 @@ It prints the list of prospective patches to be ported. See its comments about
 what it does.
 
 8. Building odp-dpdk with dpdk crypto PMD's
-======================================================
+=================================================
 
 Refer to dpdk crypto documentation for detailed building of crypto PMD's:
 http://dpdk.org/doc/guides/cryptodevs/index.html.
@@ -288,3 +291,18 @@ Before running the application, export ODP_PLATFORM_PARAMS with corresponding
 crypto vdev's.
 ex: ODP_PLATFORM_PARAMS="--vdev cryptodev_aesni_mb_pmd,max_nb_sessions=32 \
     --vdev cryptodev_null_pmd,max_nb_sessions=32"
+
+9. Using eventdev scheduling and queues
+=================================================
+
+ODP-DPDK includes experimental implementations of scheduling and queues
+using DPDK event device library. To use eventdev one must set ODP_SCHEDULER
+environment variable to "eventdev" and provide necessary platform parameters
+to DPDK.
+
+In case of the default software eventdev implementation one must also enable
+a DPDK service core, which will perform scheduling and receive packets from
+scheduled input queues.
+
+ex: ODP_SCHEDULER="eventdev" ODP_PLATFORM_PARAMS="--vdev event_sw0 -s 0x2" \
+    ./odp_scheduling -c 1

--- a/platform/linux-dpdk/include/odp_eventdev_internal.h
+++ b/platform/linux-dpdk/include/odp_eventdev_internal.h
@@ -1,0 +1,223 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP eventdev - implementation internal
+ */
+
+#ifndef ODP_EVENTDEV_H_
+#define ODP_EVENTDEV_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/plat/strong_types.h>
+#include <odp/api/queue.h>
+#include <odp_forward_typedefs_internal.h>
+#include <odp_queue_if.h>
+#include <odp_buffer_internal.h>
+#include <odp_align_internal.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/align.h>
+#include <odp/api/hints.h>
+#include <odp/api/ticketlock.h>
+#include <odp_config_internal.h>
+#include <odp_ring_st_internal.h>
+#include <odp/api/schedule_types.h>
+
+#include <rte_config.h>
+#include <rte_eventdev.h>
+
+#include <stdint.h>
+
+#define MAX_EVENT_QUEUES UINT8_MAX
+ODP_STATIC_ASSERT(sizeof(((struct rte_event *)0)->queue_id) == sizeof(uint8_t),
+		  "eventdev queue ID size changed");
+
+#define RX_ADAPTER_INIT           0
+#define RX_ADAPTER_STOPPED        1
+#define RX_ADAPTER_RUNNING        2
+
+/* Maximum schedule burst size */
+#define MAX_SCHED_BURST 128
+ODP_STATIC_ASSERT(MAX_SCHED_BURST <= UINT16_MAX,
+		  "too large schedule burst");
+
+/* Number of scheduling groups */
+#define NUM_SCHED_GRPS 32
+
+typedef struct {
+	uint8_t id;
+	uint8_t status;
+} eventdev_queue_t;
+
+struct queue_entry_s {
+	odp_ticketlock_t  ODP_ALIGNED_CACHE lock;
+	ring_st_t         ring_st;
+	int               status;
+	eventdev_queue_t  event_queue;
+
+	queue_enq_fn_t       ODP_ALIGNED_CACHE enqueue;
+	queue_deq_fn_t       dequeue;
+	queue_enq_multi_fn_t enqueue_multi;
+	queue_deq_multi_fn_t dequeue_multi;
+
+	uint32_t          index;
+	odp_queue_t       handle;
+	odp_queue_type_t  type;
+	odp_queue_param_t param;
+	odp_pktin_queue_t pktin;
+	odp_pktout_queue_t pktout;
+	char              name[ODP_QUEUE_NAME_LEN];
+};
+
+union queue_entry_u {
+	struct queue_entry_s s;
+	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct queue_entry_s))];
+};
+
+/* Eventdev global data */
+typedef struct {
+	odp_shm_t   shm;
+	struct rte_event_dev_config config;
+	struct {
+		odp_spinlock_t lock;
+		int  status;
+		uint8_t id;
+		uint8_t single_queue;
+	} rx_adapter;
+	odp_atomic_u32_t num_started;
+	uint8_t     dev_id;
+	uint8_t     num_event_ports;
+	uint8_t     num_prio;
+
+	odp_ticketlock_t ODP_ALIGNED_CACHE lock;
+	queue_entry_t   queue[ODP_CONFIG_QUEUES];
+	odp_queue_t queue_id_to_queue[MAX_EVENT_QUEUES];
+	struct {
+		eventdev_queue_t atomic[MAX_EVENT_QUEUES];
+		eventdev_queue_t ordered[MAX_EVENT_QUEUES];
+		eventdev_queue_t parallel[MAX_EVENT_QUEUES];
+		uint8_t num_atomic;
+		uint8_t num_ordered;
+		uint8_t num_parallel;
+	} event_queue;
+	pktio_entry_t *pktio[RTE_MAX_ETHPORTS];
+
+	struct {
+		odp_spinlock_t lock;
+		uint8_t linked;
+	} port[ODP_THREAD_COUNT_MAX];
+
+	struct {
+		uint32_t max_queue_size;
+		uint32_t default_queue_size;
+	} plain_config;
+
+	struct {
+		uint32_t max_queue_size;
+	} sched_config;
+
+	/* Schedule groups */
+	odp_thrmask_t    mask_all;
+	struct {
+		char           name[ODP_SCHED_GROUP_NAME_LEN];
+		odp_thrmask_t  mask;
+		uint8_t	       allocated;
+		queue_entry_t *queue[MAX_EVENT_QUEUES];
+	} grp[NUM_SCHED_GRPS];
+	odp_spinlock_t   grp_lock;
+} eventdev_global_t;
+
+/* Eventdev local data */
+typedef struct {
+	struct {
+		struct rte_event event[MAX_SCHED_BURST];
+		uint16_t idx;
+		uint16_t count;
+	} cache;
+	uint8_t thr;
+	uint8_t paused;
+	uint8_t started;
+} eventdev_local_t;
+
+extern eventdev_global_t *eventdev_gbl;
+extern __thread eventdev_local_t eventdev_local;
+
+int service_setup(uint32_t service_id);
+
+int link_all_queues(uint8_t dev_id,
+		    const struct rte_event_dev_config *dev_conf);
+
+int unlink_all_queues(uint8_t dev_id,
+		      const struct rte_event_dev_config *dev_conf);
+
+int resume_scheduling(uint8_t dev_id, uint8_t port_id);
+
+void rx_adapter_port_stop(uint16_t port_id);
+
+int rx_adapter_close(void);
+
+/* Check that DPDK schedule types have not changed */
+ODP_STATIC_ASSERT(RTE_SCHED_TYPE_ORDERED == 0,
+		  "RTE_SCHED_TYPE_ORDERED value changed");
+ODP_STATIC_ASSERT(RTE_SCHED_TYPE_ATOMIC == 1,
+		  "RTE_SCHED_TYPE_ATOMIC value changed");
+ODP_STATIC_ASSERT(RTE_SCHED_TYPE_PARALLEL == 2,
+		  "RTE_SCHED_TYPE_PARALLEL value changed");
+
+static inline uint8_t event_schedule_type(odp_schedule_sync_t sync)
+{
+	/* This shortcut matches ODP scheduling types to RTE_SCHED_TYPE_ORDERED,
+	 * RTE_SCHED_TYPE_ATOMIC and RTE_SCHED_TYPE_PARALLE. */
+	return 2 - (uint8_t)sync;
+}
+
+static inline queue_t queue_index_to_qint(uint32_t queue_id)
+{
+	return (queue_t)&eventdev_gbl->queue[queue_id];
+}
+
+static inline uint32_t queue_to_index(odp_queue_t handle)
+{
+	return _odp_typeval(handle) - 1;
+}
+
+static inline odp_queue_t queue_from_index(uint32_t queue_id)
+{
+	return _odp_cast_scalar(odp_queue_t, queue_id + 1);
+}
+
+static inline queue_entry_t *qentry_from_int(queue_t q_int)
+{
+	return (queue_entry_t *)(void *)(q_int);
+}
+
+static inline queue_t qentry_to_int(queue_entry_t *qentry)
+{
+	return (queue_t)(qentry);
+}
+
+static inline queue_entry_t *get_qentry(uint32_t queue_id)
+{
+	return &eventdev_gbl->queue[queue_id];
+}
+
+static inline queue_entry_t *handle_to_qentry(odp_queue_t handle)
+{
+	uint32_t queue_id = queue_to_index(handle);
+
+	return get_qentry(queue_id);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/include/odp_packet_io_internal.h
+++ b/platform/linux-dpdk/include/odp_packet_io_internal.h
@@ -218,6 +218,8 @@ static inline void pktio_cls_enabled_set(pktio_entry_t *entry, int ena)
 	entry->s.cls_enabled = ena;
 }
 
+int input_pkts(pktio_entry_t *pktio_entry, odp_packet_t pkt_table[], int num);
+
 extern const pktio_if_ops_t loopback_pktio_ops;
 extern const pktio_if_ops_t null_pktio_ops;
 extern const pktio_if_ops_t dpdk_pktio_ops;

--- a/platform/linux-dpdk/odp_packet_dpdk.c
+++ b/platform/linux-dpdk/odp_packet_dpdk.c
@@ -670,33 +670,14 @@ static inline int pkt_set_ol_rx(odp_pktin_config_opt_t *pktin_cfg,
 	return 0;
 }
 
-static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
-			 odp_packet_t pkt_table[], int num)
+int input_pkts(pktio_entry_t *pktio_entry, odp_packet_t pkt_table[], int num)
 {
-	uint16_t nb_rx, i;
-	odp_packet_t *saved_pkt_table;
-	pkt_dpdk_t * const pkt_dpdk = &pktio_entry->s.pkt_dpdk;
+	uint16_t i;
 	odp_pktin_config_opt_t *pktin_cfg = &pktio_entry->s.config.pktin;
 	odp_proto_layer_t parse_layer = pktio_entry->s.config.parser.layer;
 	odp_pktio_t input = pktio_entry->s.handle;
-	uint8_t min = pkt_dpdk->min_rx_burst;
 	odp_time_t ts_val;
 	odp_time_t *ts = NULL;
-
-	if (odp_unlikely(min > num)) {
-		ODP_DBG("PMD requires >%d buffers burst. "
-			"Current %d, dropped %d\n", min, num, min - num);
-		saved_pkt_table = pkt_table;
-		pkt_table = malloc(min * sizeof(odp_packet_t));
-	}
-
-	if (!pkt_dpdk->lockless_rx)
-		odp_ticketlock_lock(&pkt_dpdk->rx_lock[index]);
-
-	nb_rx = rte_eth_rx_burst(pkt_dpdk->port_id,
-				 (uint16_t)index,
-				 (struct rte_mbuf **)pkt_table,
-				 (uint16_t)RTE_MAX(num, min));
 
 	if (pktio_entry->s.config.pktin.bit.ts_all ||
 	    pktio_entry->s.config.pktin.bit.ts_ptp) {
@@ -704,18 +685,7 @@ static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 		ts = &ts_val;
 	}
 
-	if (nb_rx == 0 && !pkt_dpdk->lockless_tx) {
-		pool_t *pool = pool_entry_from_hdl(pktio_entry->s.pool);
-		struct rte_mempool *rte_mempool = pool->rte_mempool;
-
-		if (rte_mempool_avail_count(rte_mempool) == 0)
-			_odp_pktio_send_completion(pktio_entry);
-	}
-
-	if (!pkt_dpdk->lockless_rx)
-		odp_ticketlock_unlock(&pkt_dpdk->rx_lock[index]);
-
-	for (i = 0; i < nb_rx; ++i) {
+	for (i = 0; i < num; ++i) {
 		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt_table[i]);
 
 		packet_init(pkt_hdr);
@@ -727,21 +697,10 @@ static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 		packet_set_ts(pkt_hdr, ts);
 	}
 
-	if (odp_unlikely(min > num)) {
-		memcpy(saved_pkt_table, pkt_table,
-		       num * sizeof(odp_packet_t));
-		for (i = num; i < nb_rx; i++)
-			odp_packet_free(pkt_table[i]);
-		nb_rx = RTE_MIN(num, nb_rx);
-		free(pkt_table);
-		pktio_entry->s.stats.in_discards += min - num;
-		pkt_table = saved_pkt_table;
-	}
-
 	if (pktio_cls_enabled(pktio_entry)) {
 		int failed = 0, success = 0;
 
-		for (i = 0; i < nb_rx; i++) {
+		for (i = 0; i < num; i++) {
 			odp_packet_t new_pkt;
 			odp_pool_t new_pool;
 			uint8_t *pkt_addr;
@@ -779,15 +738,15 @@ static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 			++success;
 		}
 		pktio_entry->s.stats.in_errors += failed;
-		pktio_entry->s.stats.in_ucast_pkts += nb_rx - failed;
-		nb_rx = success;
+		pktio_entry->s.stats.in_ucast_pkts += num - failed;
+		num = success;
 	}
 
 	if (pktin_cfg->all_bits & PKTIN_CSUM_BITS) {
 		int j;
 		odp_packet_t pkt;
 
-		for (i = 0, j = 0; i < nb_rx; i++) {
+		for (i = 0, j = 0; i < num; i++) {
 			pkt = pkt_table[i];
 
 			if (pkt_set_ol_rx(pktin_cfg, packet_hdr(pkt),
@@ -800,9 +759,61 @@ static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 			j++;
 		}
 
-		nb_rx = j;
+		num = j;
 	}
-	return nb_rx;
+	return num;
+}
+
+static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
+			 odp_packet_t pkt_table[], int num)
+{
+	uint16_t nb_rx, i;
+	odp_packet_t *saved_pkt_table;
+	pkt_dpdk_t * const pkt_dpdk = &pktio_entry->s.pkt_dpdk;
+	uint8_t min = pkt_dpdk->min_rx_burst;
+
+	if (odp_unlikely(min > num)) {
+		ODP_DBG("PMD requires >%d buffers burst. "
+			"Current %d, dropped %d\n", min, num, min - num);
+		saved_pkt_table = pkt_table;
+		pkt_table = malloc(min * sizeof(odp_packet_t));
+	}
+
+	if (!pkt_dpdk->lockless_rx)
+		odp_ticketlock_lock(&pkt_dpdk->rx_lock[index]);
+
+	nb_rx = rte_eth_rx_burst(pkt_dpdk->port_id,
+				 (uint16_t)index,
+				 (struct rte_mbuf **)pkt_table,
+				 (uint16_t)RTE_MAX(num, min));
+
+	if (nb_rx == 0 && !pkt_dpdk->lockless_tx) {
+		pool_t *pool = pool_entry_from_hdl(pktio_entry->s.pool);
+		struct rte_mempool *rte_mempool = pool->rte_mempool;
+
+		if (rte_mempool_avail_count(rte_mempool) == 0)
+			_odp_pktio_send_completion(pktio_entry);
+	}
+
+	if (!pkt_dpdk->lockless_rx)
+		odp_ticketlock_unlock(&pkt_dpdk->rx_lock[index]);
+
+	if (odp_unlikely(min > num)) {
+		memcpy(saved_pkt_table, pkt_table,
+		       num * sizeof(odp_packet_t));
+		for (i = num; i < nb_rx; i++)
+			odp_packet_free(pkt_table[i]);
+		nb_rx = RTE_MIN(num, nb_rx);
+		free(pkt_table);
+		pktio_entry->s.stats.in_discards += min - num;
+		pkt_table = saved_pkt_table;
+	}
+
+	/* Packets may also me received through eventdev, so don't add any
+	 * processing here. Instead, perform all processing in input_pkts()
+	 * which is also called by eventdev. */
+
+	return input_pkts(pktio_entry, pkt_table, nb_rx);
 }
 
 static inline int check_proto(void *l3_hdr, odp_bool_t *l3_proto_v4,

--- a/platform/linux-dpdk/odp_queue_eventdev.c
+++ b/platform/linux-dpdk/odp_queue_eventdev.c
@@ -1,0 +1,1207 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odp/api/queue.h>
+#include <odp_queue_if.h>
+#include <odp/api/std_types.h>
+#include <odp/api/align.h>
+#include <odp/api/buffer.h>
+#include <odp_buffer_internal.h>
+#include <odp_pool_internal.h>
+#include <odp_internal.h>
+#include <odp/api/shared_memory.h>
+#include <odp/api/schedule.h>
+#include <odp_schedule_if.h>
+#include <odp_config_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_debug_internal.h>
+#include <odp/api/hints.h>
+#include <odp/api/sync.h>
+#include <odp/api/traffic_mngr.h>
+#include <odp_libconfig_internal.h>
+#include <odp_eventdev_internal.h>
+
+#include <rte_config.h>
+#include <rte_service.h>
+#include <rte_eventdev.h>
+
+#include <odp/api/plat/ticketlock_inlines.h>
+
+#define LOCK(queue_ptr)      _odp_ticketlock_lock(&((queue_ptr)->s.lock))
+#define UNLOCK(queue_ptr)    _odp_ticketlock_unlock(&((queue_ptr)->s.lock))
+#define LOCK_INIT(queue_ptr)  odp_ticketlock_init(&((queue_ptr)->s.lock))
+
+#include <string.h>
+#include <inttypes.h>
+
+#define MIN_QUEUE_SIZE 8
+#define DEFAULT_QUEUE_SIZE (4 * 1024)
+#define MAX_QUEUE_SIZE (8 * 1024)
+
+#define EVENT_QUEUE_FLOWS 32
+
+#define EVENT_QUEUE_STATUS_UNUSED    0
+#define EVENT_QUEUE_STATUS_FREE      1
+#define EVENT_QUEUE_STATUS_RESERVED  2
+
+#define QUEUE_STATUS_FREE         0
+#define QUEUE_STATUS_READY        1
+#define QUEUE_STATUS_SCHED        2
+
+/* Number of priority levels  */
+#define NUM_PRIO 8
+
+ODP_STATIC_ASSERT(ODP_SCHED_PRIO_LOWEST == (NUM_PRIO - 1),
+		  "lowest_prio_does_not_match_with_num_prios");
+
+ODP_STATIC_ASSERT((ODP_SCHED_PRIO_NORMAL > 0) &&
+		  (ODP_SCHED_PRIO_NORMAL < (NUM_PRIO - 1)),
+		  "normal_prio_is_not_between_highest_and_lowest");
+
+/* Thread local eventdev context */
+__thread eventdev_local_t eventdev_local;
+
+/* Global eventdev context */
+eventdev_global_t *eventdev_gbl;
+
+static int queue_init(queue_entry_t *queue, const char *name,
+		      const odp_queue_param_t *param);
+
+static eventdev_queue_t *event_queues(odp_schedule_sync_t sync)
+{
+	if (sync == ODP_SCHED_SYNC_PARALLEL)
+		return eventdev_gbl->event_queue.parallel;
+	else if (sync == ODP_SCHED_SYNC_ATOMIC)
+		return eventdev_gbl->event_queue.atomic;
+	else if (sync == ODP_SCHED_SYNC_ORDERED)
+		return eventdev_gbl->event_queue.ordered;
+
+	ODP_ABORT("Invalid schedule sync type\n");
+	return NULL;
+}
+
+static int read_config_file(eventdev_global_t *eventdev)
+{
+	const char *str;
+	int val = 0;
+
+	ODP_PRINT("\nScheduler config\n----------------\n");
+
+	str = "sched_eventdev.num_atomic_queues";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n", str, val);
+	eventdev->event_queue.num_atomic = val;
+
+	str = "sched_eventdev.num_ordered_queues";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n", str, val);
+	eventdev->event_queue.num_ordered = val;
+
+	str = "sched_eventdev.num_parallel_queues";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n\n", str, val);
+	eventdev->event_queue.num_parallel = val;
+
+	str = "sched_eventdev.num_ports";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n\n", str, val);
+	eventdev->num_event_ports = val;
+
+	return 0;
+}
+
+static int queue_capa(odp_queue_capability_t *capa, int sched)
+{
+	uint16_t max_sched;
+
+	memset(capa, 0, sizeof(odp_queue_capability_t));
+
+	/* Reserve some queues for internal use */
+	capa->max_queues        = ODP_CONFIG_QUEUES;
+	capa->plain.max_num     = ODP_CONFIG_QUEUES;
+	capa->plain.max_size    = eventdev_gbl->plain_config.max_queue_size - 1;
+	capa->plain.lockfree.max_num  = 0;
+	capa->plain.lockfree.max_size = 0;
+
+	max_sched = RTE_MAX(RTE_MAX(eventdev_gbl->event_queue.num_atomic,
+				    eventdev_gbl->event_queue.num_ordered),
+			    eventdev_gbl->event_queue.num_parallel);
+	capa->sched.max_num     = RTE_MIN(ODP_CONFIG_QUEUES, max_sched);
+	capa->sched.max_size    = eventdev_gbl->config.nb_events_limit;
+
+	if (sched) {
+		capa->max_ordered_locks = sched_fn->max_ordered_locks();
+		capa->max_sched_groups  = sched_fn->num_grps();
+		capa->sched_prios       = odp_schedule_num_prio();
+	}
+
+	return 0;
+}
+
+static void print_dev_info(const struct rte_event_dev_info *info)
+{
+	ODP_PRINT("\nEvent device info\n"
+		  "-----------------\n"
+		  "driver name: %s\n"
+		  "min_dequeue_timeout_ns: %" PRIu32 "\n"
+		  "max_dequeue_timeout_ns: %" PRIu32 "\n"
+		  "dequeue_timeout_ns: %" PRIu32 "\n"
+		  "max_event_queues: %" PRIu8 "\n"
+		  "max_event_queue_flows: %" PRIu32 "\n"
+		  "max_event_queue_priority_levels: %" PRIu8 "\n"
+		  "max_event_priority_levels: %" PRIu8 "\n"
+		  "max_event_ports: %" PRIu8 "\n"
+		  "max_event_port_dequeue_depth: %" PRIu8 "\n"
+		  "max_event_port_enqueue_depth: %" PRIu32 "\n"
+		  "max_num_events: %" PRId32 "\n"
+		  "event_dev_cap: %" PRIu32 "\n",
+		  info->driver_name,
+		  info->min_dequeue_timeout_ns,
+		  info->max_dequeue_timeout_ns,
+		  info->dequeue_timeout_ns,
+		  info->max_event_queues,
+		  info->max_event_queue_flows,
+		  info->max_event_queue_priority_levels,
+		  info->max_event_priority_levels,
+		  info->max_event_ports,
+		  info->max_event_port_dequeue_depth,
+		  info->max_event_port_enqueue_depth,
+		  info->max_num_events,
+		  info->event_dev_cap);
+}
+
+int service_setup(uint32_t service_id)
+{
+	uint32_t cores[RTE_MAX_LCORE];
+	uint32_t lcore = 0;
+	int32_t num_cores;
+	int32_t num_serv;
+	int32_t min_num_serv = INT32_MAX;
+
+	if (!rte_service_lcore_count()) {
+		ODP_ERR("No service cores available\n");
+		return -1;
+	}
+
+	/* Use the service core with the smallest number of running services */
+	num_cores = rte_service_lcore_list(cores, RTE_MAX_LCORE);
+	while (num_cores--) {
+		rte_service_map_lcore_set(service_id, cores[num_cores], 0);
+		num_serv = rte_service_lcore_count_services(cores[num_cores]);
+		if (num_serv < min_num_serv) {
+			lcore = cores[num_cores];
+			min_num_serv = num_serv;
+		}
+	}
+	if (rte_service_map_lcore_set(service_id, lcore, 1)) {
+		ODP_ERR("Unable to map service to core\n");
+		return -1;
+	}
+	return 0;
+}
+
+static int alloc_queues(eventdev_global_t *eventdev,
+			const struct rte_event_dev_info *info)
+{
+	int num_queues;
+
+	if (!eventdev->event_queue.num_atomic &&
+	    !eventdev->event_queue.num_ordered &&
+	    !eventdev->event_queue.num_parallel) {
+		uint8_t queue_per_type = info->max_event_queues / 3;
+
+		/* Divide eventdev queues evenly to ODP queue types */
+		eventdev->event_queue.num_atomic = queue_per_type;
+		eventdev->event_queue.num_ordered = queue_per_type;
+		eventdev->event_queue.num_parallel = queue_per_type;
+
+		num_queues = 3 * queue_per_type;
+	} else {
+		num_queues = eventdev->event_queue.num_atomic +
+			     eventdev->event_queue.num_ordered +
+			     eventdev->event_queue.num_parallel;
+	}
+
+	return num_queues;
+}
+
+static int setup_queues(uint8_t dev_id, uint8_t first_queue_id,
+			uint8_t num_queues, uint32_t num_flows,
+			odp_schedule_sync_t sync)
+{
+	eventdev_queue_t *queues = event_queues(sync);
+	uint8_t i, j;
+	uint8_t priority = ODP_SCHED_PRIO_NORMAL;
+
+	for (i = first_queue_id, j = 0; j < num_queues; i++, j++) {
+		struct rte_event_queue_conf queue_conf;
+		eventdev_queue_t *event_queue = &queues[i];
+
+		if (rte_event_queue_default_conf_get(dev_id, i, &queue_conf)) {
+			ODP_ERR("rte_event_queue_default_conf_get failed\n");
+			return -1;
+		}
+		queue_conf.schedule_type = event_schedule_type(sync);
+		queue_conf.priority = priority;
+
+		if (sync == ODP_SCHED_SYNC_ATOMIC)
+			queue_conf.nb_atomic_flows = num_flows;
+		else if (sync == ODP_SCHED_SYNC_ORDERED)
+			queue_conf.nb_atomic_order_sequences = num_flows;
+
+		if (rte_event_queue_setup(dev_id, i, &queue_conf)) {
+			ODP_ERR("rte_event_queue_setup failed\n");
+			return -1;
+		}
+		event_queue->id = i;
+		event_queue->status = EVENT_QUEUE_STATUS_FREE;
+	}
+	return 0;
+}
+
+static int configure_queues(const eventdev_global_t *eventdev, uint8_t dev_id,
+			    uint32_t num_flows)
+{
+	uint8_t first_queue_id = 0;
+
+	if (setup_queues(dev_id, first_queue_id,
+			 eventdev->event_queue.num_atomic, num_flows,
+			 ODP_SCHED_SYNC_ATOMIC))
+		return -1;
+	first_queue_id += eventdev->event_queue.num_atomic;
+
+	if (setup_queues(dev_id, first_queue_id,
+			 eventdev->event_queue.num_parallel, num_flows,
+			 ODP_SCHED_SYNC_PARALLEL))
+		return -1;
+	first_queue_id += eventdev->event_queue.num_parallel;
+
+	if (setup_queues(dev_id, first_queue_id,
+			 eventdev->event_queue.num_ordered, num_flows,
+			 ODP_SCHED_SYNC_ORDERED))
+		return -1;
+
+	return 0;
+}
+
+/* Dummy link all queues to port zero to pass evendev start */
+int link_all_queues(uint8_t dev_id,
+		    const struct rte_event_dev_config *dev_conf)
+{
+	int ret;
+	uint8_t priority = RTE_EVENT_DEV_PRIORITY_NORMAL;
+	uint8_t queue_id;
+
+	for (queue_id = 0; queue_id < dev_conf->nb_event_queues; queue_id++) {
+		ret = rte_event_port_link(dev_id, 0, &queue_id, &priority, 1);
+		if (ret != 1) {
+			ODP_ERR("rte_event_port_link failed: %d\n", ret);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/* Remove dummy links required for evendev start */
+int unlink_all_queues(uint8_t dev_id,
+		      const struct rte_event_dev_config *dev_conf)
+{
+	int i;
+
+	for (i = 0; i < dev_conf->nb_event_ports; i++) {
+		if (rte_event_port_unlink(dev_id, i, NULL, 0) < 0) {
+			ODP_ERR("rte_event_port_unlink failed\n");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static int configure_ports(uint8_t dev_id, uint8_t nb_ports)
+{
+	struct rte_event_port_conf port_conf;
+	uint8_t i;
+
+	for (i = 0; i < nb_ports; i++) {
+		if (rte_event_port_default_conf_get(dev_id, i, &port_conf)) {
+			ODP_ERR("rte_event_port_default_conf_get failed\n");
+			return -1;
+		}
+
+		if (rte_event_port_setup(dev_id, i, &port_conf)) {
+			ODP_ERR("rte_event_port_setup failed\n");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static int init_event_dev(void)
+{
+	uint32_t num_flows;
+	uint8_t dev_id = 0;
+	uint8_t rx_adapter_id = 0;
+	struct rte_event_dev_info info;
+	struct rte_event_dev_config config;
+	int ret;
+	int i;
+
+	if (rte_event_dev_count() < 1) {
+		ODP_ERR("No eventdev devices found\n");
+		return -1;
+	}
+
+	if (read_config_file(eventdev_gbl))
+		return -1;
+
+	eventdev_gbl->dev_id = dev_id;
+	eventdev_gbl->rx_adapter.id = rx_adapter_id;
+	eventdev_gbl->rx_adapter.status = RX_ADAPTER_INIT;
+	odp_spinlock_init(&eventdev_gbl->rx_adapter.lock);
+	odp_atomic_init_u32(&eventdev_gbl->num_started, 0);
+
+	for (i = 0; i < ODP_THREAD_COUNT_MAX; i++) {
+		odp_spinlock_init(&eventdev_gbl->port[i].lock);
+		eventdev_gbl->port[i].linked = 0;
+	}
+
+	if (rte_event_dev_info_get(dev_id, &info)) {
+		ODP_ERR("rte_event_dev_info_get failed\n");
+		return -1;
+	}
+	print_dev_info(&info);
+
+	eventdev_gbl->num_prio = NUM_PRIO;
+	if (!(info.event_dev_cap & RTE_EVENT_DEV_CAP_EVENT_QOS)) {
+		ODP_PRINT("  Only one QoS level supported!\n");
+		eventdev_gbl->num_prio = 1;
+	}
+
+	memset(&config, 0, sizeof(struct rte_event_dev_config));
+	config.dequeue_timeout_ns = 0;
+	config.nb_events_limit  = info.max_num_events;
+	config.nb_event_queues = alloc_queues(eventdev_gbl, &info);
+
+	config.nb_event_ports = (ODP_THREAD_COUNT_MAX < info.max_event_ports) ?
+			ODP_THREAD_COUNT_MAX : info.max_event_ports;
+	/* RX adapter requires additional port which is reserved when
+	 * rte_event_eth_rx_adapter_queue_add() is called. */
+	config.nb_event_ports -= 1;
+	if (eventdev_gbl->num_event_ports &&
+	    eventdev_gbl->num_event_ports < config.nb_event_ports)
+		config.nb_event_ports = eventdev_gbl->num_event_ports;
+
+	num_flows = (EVENT_QUEUE_FLOWS < info.max_event_queue_flows) ?
+			EVENT_QUEUE_FLOWS : info.max_event_queue_flows;
+	config.nb_event_queue_flows = num_flows;
+	config.nb_event_port_dequeue_depth = (MAX_SCHED_BURST <
+			info.max_event_port_dequeue_depth) ? MAX_SCHED_BURST :
+					info.max_event_port_dequeue_depth;
+	config.nb_event_port_enqueue_depth = (MAX_SCHED_BURST <
+			info.max_event_port_enqueue_depth) ? MAX_SCHED_BURST :
+					info.max_event_port_enqueue_depth;
+	/* RTE_EVENT_DEV_CFG_PER_DEQUEUE_TIMEOUT not supported by the SW
+	 * eventdev */
+	config.event_dev_cfg = 0;
+
+	ret = rte_event_dev_configure(dev_id, &config);
+	if (ret < 0) {
+		ODP_ERR("rte_event_dev_configure failed\n");
+		return -1;
+	}
+	eventdev_gbl->config = config;
+	eventdev_gbl->num_event_ports = config.nb_event_ports;
+
+	if (configure_ports(dev_id, config.nb_event_ports)) {
+		ODP_ERR("Configuring eventdev ports failed\n");
+		return -1;
+	}
+
+	if (configure_queues(eventdev_gbl, dev_id, num_flows)) {
+		ODP_ERR("Configuring eventdev queues failed\n");
+		return -1;
+	}
+
+	/* Eventdev requires that each queue is linked to at least one
+	 * port at startup. */
+	link_all_queues(dev_id, &config);
+
+	if (!(info.event_dev_cap & RTE_EVENT_DEV_CAP_DISTRIBUTED_SCHED)) {
+		uint32_t service_id;
+
+		ret = rte_event_dev_service_id_get(dev_id, &service_id);
+		if (ret) {
+			ODP_ERR("Unable to retrieve service ID\n");
+			return -1;
+		}
+		if (service_setup(service_id)) {
+			ODP_ERR("Failed to setup service core\n");
+			return -1;
+		}
+	}
+
+	if (rte_event_dev_start(dev_id)) {
+		ODP_ERR("rte_event_dev_start failed\n");
+		return -1;
+	}
+
+	/* Unlink all ports from queues. Thread specific ports will be linked
+	 * when the application calls schedule/enqueue for the first time. */
+	if (unlink_all_queues(dev_id, &config)) {
+		rte_event_dev_stop(dev_id);
+		rte_event_dev_close(dev_id);
+		return -1;
+	}
+
+	/* Scheduling groups */
+	odp_spinlock_init(&eventdev_gbl->grp_lock);
+
+	for (i = 0; i < NUM_SCHED_GRPS; i++) {
+		memset(eventdev_gbl->grp[i].name, 0,
+		       ODP_SCHED_GROUP_NAME_LEN);
+		odp_thrmask_zero(&eventdev_gbl->grp[i].mask);
+	}
+
+	eventdev_gbl->grp[ODP_SCHED_GROUP_ALL].allocated = 1;
+	eventdev_gbl->grp[ODP_SCHED_GROUP_WORKER].allocated = 1;
+	eventdev_gbl->grp[ODP_SCHED_GROUP_CONTROL].allocated = 1;
+
+	odp_thrmask_setall(&eventdev_gbl->mask_all);
+
+	return 0;
+}
+
+static int queue_init_global(void)
+{
+	uint32_t max_queue_size;
+	uint32_t i;
+	odp_shm_t shm;
+	odp_queue_capability_t capa;
+
+	ODP_DBG("Starts...\n");
+
+	shm = odp_shm_reserve("_odp_eventdev_gbl",
+			      sizeof(eventdev_global_t),
+			      ODP_CACHE_LINE_SIZE, 0);
+
+	eventdev_gbl = odp_shm_addr(shm);
+
+	if (eventdev_gbl == NULL)
+		return -1;
+
+	memset(eventdev_gbl, 0, sizeof(eventdev_global_t));
+	eventdev_gbl->shm = shm;
+
+	if (init_event_dev())
+		return -1;
+
+	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+		/* init locks */
+		queue_entry_t *queue = get_qentry(i);
+
+		LOCK_INIT(queue);
+		queue->s.index  = i;
+		queue->s.handle = queue_from_index(i);
+	}
+	odp_ticketlock_init(&eventdev_gbl->lock);
+
+	max_queue_size = eventdev_gbl->config.nb_events_limit;
+	eventdev_gbl->plain_config.default_queue_size = DEFAULT_QUEUE_SIZE;
+	eventdev_gbl->plain_config.max_queue_size = MAX_QUEUE_SIZE;
+	eventdev_gbl->sched_config.max_queue_size = max_queue_size;
+
+	queue_capa(&capa, 0);
+
+	ODP_DBG("... done.\n");
+	ODP_DBG("  queue_entry_t size %u\n", sizeof(queue_entry_t));
+	ODP_DBG("  max num queues     %u\n", capa.max_queues);
+	ODP_DBG("  max plain queue size     %u\n", capa.plain.max_size);
+	ODP_DBG("  max sched queue size     %u\n", capa.sched.max_size);
+	ODP_DBG("  max num lockfree   %u\n", capa.plain.lockfree.max_num);
+	ODP_DBG("  max lockfree size  %u\n\n", capa.plain.lockfree.max_size);
+
+	return 0;
+}
+
+static int queue_init_local(void)
+{
+	int thread_id = odp_thread_id();
+
+	memset(&eventdev_local, 0, sizeof(eventdev_local_t));
+
+	ODP_ASSERT(thread_id <= UINT8_MAX);
+	eventdev_local.thr = thread_id;
+	eventdev_local.paused = 0;
+	eventdev_local.started = 0;
+
+	return 0;
+}
+
+static int queue_term_local(void)
+{
+	return 0;
+}
+
+static int queue_term_global(void)
+{
+	int ret = 0;
+	queue_entry_t *queue;
+	int i;
+
+	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+		queue = &eventdev_gbl->queue[i];
+		LOCK(queue);
+		if (queue->s.status != QUEUE_STATUS_FREE) {
+			ODP_ERR("Not destroyed queue: %s\n", queue->s.name);
+			ret = -1;
+		}
+		UNLOCK(queue);
+	}
+
+	if (rx_adapter_close())
+		ret = -1;
+
+	rte_event_dev_stop(eventdev_gbl->dev_id);
+	if (rte_event_dev_close(eventdev_gbl->dev_id)) {
+		ODP_ERR("Failed to close event device\n");
+		ret = -1;
+	}
+
+	if (odp_shm_free(eventdev_gbl->shm)) {
+		ODP_ERR("Shm free failed for evendev\n");
+		ret = -1;
+	}
+
+	return ret;
+}
+
+static int queue_capability(odp_queue_capability_t *capa)
+{
+	return queue_capa(capa, 1);
+}
+
+static odp_queue_type_t queue_type(odp_queue_t handle)
+{
+	return handle_to_qentry(handle)->s.type;
+}
+
+static odp_schedule_sync_t queue_sched_type(odp_queue_t handle)
+{
+	return handle_to_qentry(handle)->s.param.sched.sync;
+}
+
+static odp_schedule_prio_t queue_sched_prio(odp_queue_t handle)
+{
+	return handle_to_qentry(handle)->s.param.sched.prio;
+}
+
+static odp_schedule_group_t queue_sched_group(odp_queue_t handle)
+{
+	return handle_to_qentry(handle)->s.param.sched.group;
+}
+
+static uint32_t queue_lock_count(odp_queue_t handle)
+{
+	queue_entry_t *queue = handle_to_qentry(handle);
+
+	return queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
+		queue->s.param.sched.lock_count : 0;
+}
+
+static odp_queue_t queue_create(const char *name,
+				const odp_queue_param_t *param)
+{
+	uint32_t i;
+	queue_entry_t *queue;
+	odp_queue_t handle = ODP_QUEUE_INVALID;
+	odp_queue_type_t type = ODP_QUEUE_TYPE_PLAIN;
+	odp_queue_param_t default_param;
+
+	if (param == NULL) {
+		odp_queue_param_init(&default_param);
+		param = &default_param;
+	}
+
+	if (param->nonblocking == ODP_BLOCKING &&
+	    param->type == ODP_QUEUE_TYPE_PLAIN) {
+		if (param->size > eventdev_gbl->plain_config.max_queue_size) {
+			ODP_ERR("Invalid queue size\n");
+			return ODP_QUEUE_INVALID;
+		}
+	} else if (param->nonblocking == ODP_BLOCKING &&
+		   param->type == ODP_QUEUE_TYPE_SCHED) {
+		if (param->size > eventdev_gbl->sched_config.max_queue_size) {
+			ODP_ERR("Invalid queue size\n");
+			return ODP_QUEUE_INVALID;
+		}
+	} else {
+		ODP_ERR("Unsupported queue blocking status\n");
+		return ODP_QUEUE_INVALID;
+	}
+
+	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+		queue = &eventdev_gbl->queue[i];
+
+		if (queue->s.status != QUEUE_STATUS_FREE)
+			continue;
+
+		LOCK(queue);
+		if (queue->s.status == QUEUE_STATUS_FREE) {
+			if (queue_init(queue, name, param)) {
+				UNLOCK(queue);
+				ODP_ERR("Queue init failed\n");
+				return ODP_QUEUE_INVALID;
+			}
+
+			type = queue->s.type;
+
+			if (type == ODP_QUEUE_TYPE_SCHED)
+				queue->s.status = QUEUE_STATUS_SCHED;
+			else
+				queue->s.status = QUEUE_STATUS_READY;
+
+			handle = queue->s.handle;
+			UNLOCK(queue);
+			break;
+		}
+		UNLOCK(queue);
+	}
+
+	if (handle == ODP_QUEUE_INVALID) {
+		ODP_ERR("Invalid handle\n");
+		return ODP_QUEUE_INVALID;
+	}
+
+	if (type == ODP_QUEUE_TYPE_SCHED) {
+		if (sched_fn->init_queue(queue->s.index,
+					 &queue->s.param.sched)) {
+			queue->s.status = QUEUE_STATUS_FREE;
+			ODP_ERR("schedule queue init failed\n");
+			return ODP_QUEUE_INVALID;
+		}
+	}
+
+	return handle;
+}
+
+static int queue_destroy(odp_queue_t handle)
+{
+	queue_entry_t *queue;
+
+	queue = handle_to_qentry(handle);
+
+	if (handle == ODP_QUEUE_INVALID)
+		return -1;
+
+	LOCK(queue);
+	if (queue->s.status == QUEUE_STATUS_FREE) {
+		UNLOCK(queue);
+		ODP_ERR("queue \"%s\" already free\n", queue->s.name);
+		return -1;
+	}
+	if (queue->s.type == ODP_QUEUE_TYPE_PLAIN) {
+		if (ring_st_is_empty(queue->s.ring_st) == 0) {
+			UNLOCK(queue);
+			ODP_ERR("queue \"%s\" not empty\n", queue->s.name);
+			return -1;
+		}
+		ring_st_free(queue->s.ring_st);
+	} else {
+		uint8_t queue_id = queue->s.event_queue.id;
+		eventdev_queue_t *queues;
+
+		odp_ticketlock_lock(&eventdev_gbl->lock);
+
+		queues = event_queues(queue->s.param.sched.sync);
+
+		eventdev_gbl->queue_id_to_queue[queue_id] = ODP_QUEUE_INVALID;
+		queues[queue_id].status = EVENT_QUEUE_STATUS_FREE;
+
+		odp_ticketlock_unlock(&eventdev_gbl->lock);
+	}
+
+	switch (queue->s.status) {
+	case QUEUE_STATUS_READY:
+		queue->s.status = QUEUE_STATUS_FREE;
+		break;
+	case QUEUE_STATUS_SCHED:
+		queue->s.status = QUEUE_STATUS_FREE;
+		sched_fn->destroy_queue(queue->s.index);
+		break;
+	default:
+		ODP_ABORT("Unexpected queue status\n");
+	}
+
+	UNLOCK(queue);
+
+	return 0;
+}
+
+static int queue_context_set(odp_queue_t handle, void *context,
+			     uint32_t len ODP_UNUSED)
+{
+	odp_mb_full();
+	handle_to_qentry(handle)->s.param.context = context;
+	odp_mb_full();
+	return 0;
+}
+
+static void *queue_context(odp_queue_t handle)
+{
+	return handle_to_qentry(handle)->s.param.context;
+}
+
+static odp_queue_t queue_lookup(const char *name)
+{
+	uint32_t i;
+
+	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+		queue_entry_t *queue = &eventdev_gbl->queue[i];
+
+		if (queue->s.status == QUEUE_STATUS_FREE)
+			continue;
+
+		LOCK(queue);
+		if (strcmp(name, queue->s.name) == 0) {
+			/* found it */
+			UNLOCK(queue);
+			return queue->s.handle;
+		}
+		UNLOCK(queue);
+	}
+
+	return ODP_QUEUE_INVALID;
+}
+
+static inline int enq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
+			    int num)
+{
+	queue_entry_t *queue;
+	struct rte_event ev[CONFIG_BURST_SIZE];
+	uint16_t num_enq = 0;
+	int i;
+
+	queue = qentry_from_int(q_int);
+
+	LOCK(queue);
+
+	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+		UNLOCK(queue);
+		ODP_ERR("Bad queue status\n");
+		return -1;
+	}
+
+	/* Use ring for unscheduled queues */
+	if (queue->s.type == ODP_QUEUE_TYPE_PLAIN) {
+		num_enq = ring_st_enq_multi(queue->s.ring_st,
+					    (void **)buf_hdr, num);
+		UNLOCK(queue);
+	} else {
+		uint8_t dev_id = eventdev_gbl->dev_id;
+		uint8_t port_id = eventdev_local.thr;
+		uint8_t sched = event_schedule_type(queue->s.param.sched.sync);
+		uint8_t queue_id = queue->s.event_queue.id;
+		uint8_t priority = queue->s.param.sched.prio;
+
+		UNLOCK(queue);
+
+		if (odp_unlikely(port_id >= eventdev_gbl->num_event_ports)) {
+			ODP_ERR("Max %" PRIu8 " scheduled workers supported\n",
+				eventdev_gbl->num_event_ports);
+			return 0;
+		}
+
+		/* Check that port is linked. Should not be needed but SW
+		 * eventdev schedules events to invalid ports unless this is
+		 * done. */
+		if (odp_unlikely(!eventdev_gbl->port[port_id].linked)) {
+			if (resume_scheduling(dev_id, port_id))
+				return 0;
+		}
+
+		for (i = 0; i < num; i++) {
+			ev[i].flow_id = 0;
+			ev[i].op = RTE_EVENT_OP_NEW;
+			ev[i].sched_type = sched;
+			ev[i].queue_id = queue_id;
+			ev[i].event_type = RTE_EVENT_TYPE_CPU;
+			ev[i].sub_event_type = 0;
+			ev[i].priority = priority;
+			ev[i].mbuf = &buf_hdr[i]->mb;
+		}
+
+		num_enq = rte_event_enqueue_new_burst(dev_id, port_id, ev, num);
+	}
+
+	return num_enq;
+}
+
+static int queue_int_enq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
+			       int num)
+{
+	return enq_multi(q_int, buf_hdr, num);
+}
+
+static int queue_int_enq(queue_t q_int, odp_buffer_hdr_t *buf_hdr)
+{
+	int ret;
+
+	ret = enq_multi(q_int, &buf_hdr, 1);
+
+	if (ret == 1)
+		return 0;
+	else
+		return -1;
+}
+
+static int queue_enq_multi(odp_queue_t handle, const odp_event_t ev[], int num)
+{
+	queue_entry_t *queue = handle_to_qentry(handle);
+
+	if (odp_unlikely(num == 0))
+		return 0;
+
+	if (num > QUEUE_MULTI_MAX)
+		num = QUEUE_MULTI_MAX;
+
+	return queue->s.enqueue_multi(qentry_to_int(queue),
+				      (odp_buffer_hdr_t **)(uintptr_t)ev, num);
+}
+
+static int queue_enq(odp_queue_t handle, odp_event_t ev)
+{
+	queue_entry_t *queue = handle_to_qentry(handle);
+
+	return queue->s.enqueue(qentry_to_int(queue),
+				(odp_buffer_hdr_t *)(uintptr_t)ev);
+}
+
+static inline int deq_multi(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[],
+			    int num, int update_status ODP_UNUSED)
+{
+	int num_deq;
+
+	LOCK(queue);
+
+	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+		/* Bad queue, or queue has been destroyed. */
+		UNLOCK(queue);
+		return -1;
+	}
+
+	num_deq = ring_st_deq_multi(queue->s.ring_st, (void **)buf_hdr, num);
+
+	UNLOCK(queue);
+
+	return num_deq;
+}
+
+static int queue_int_deq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
+			       int num)
+{
+	queue_entry_t *queue = qentry_from_int(q_int);
+
+	return deq_multi(queue, buf_hdr, num, 0);
+}
+
+static odp_buffer_hdr_t *queue_int_deq(queue_t q_int)
+{
+	queue_entry_t *queue = qentry_from_int(q_int);
+	odp_buffer_hdr_t *buf_hdr = NULL;
+	int ret;
+
+	ret = deq_multi(queue, &buf_hdr, 1, 0);
+
+	if (ret == 1)
+		return buf_hdr;
+	else
+		return NULL;
+}
+
+static int queue_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
+{
+	queue_entry_t *queue = handle_to_qentry(handle);
+
+	if (num > QUEUE_MULTI_MAX)
+		num = QUEUE_MULTI_MAX;
+
+	return queue->s.dequeue_multi(qentry_to_int(queue),
+				      (odp_buffer_hdr_t **)ev, num);
+}
+
+static odp_event_t queue_deq(odp_queue_t handle)
+{
+	queue_entry_t *queue = handle_to_qentry(handle);
+
+	return (odp_event_t)queue->s.dequeue(qentry_to_int(queue));
+}
+
+static int alloc_event_queue(odp_schedule_sync_t sync,
+			     eventdev_queue_t *out_queue)
+{
+	eventdev_queue_t *queues = event_queues(sync);
+	uint8_t i;
+	const char *type_str;
+
+	for (i = 0; i < MAX_EVENT_QUEUES; i++) {
+		eventdev_queue_t *event_queue = &queues[i];
+
+		if (event_queue->status == EVENT_QUEUE_STATUS_FREE) {
+			event_queue->status = EVENT_QUEUE_STATUS_RESERVED;
+			*out_queue = *event_queue;
+			return 0;
+		}
+	}
+
+	if (sync == ODP_SCHED_SYNC_ATOMIC)
+		type_str = "atomic";
+	else if (sync == ODP_SCHED_SYNC_ORDERED)
+		type_str = "ordered";
+	else
+		type_str = "parallel";
+
+	ODP_ERR("No free %s eventdev queues left\n", type_str);
+
+	return -1;
+}
+
+static int queue_init(queue_entry_t *queue, const char *name,
+		      const odp_queue_param_t *param)
+{
+	uint32_t queue_size;
+
+	if (name == NULL) {
+		queue->s.name[0] = 0;
+	} else {
+		strncpy(queue->s.name, name, ODP_QUEUE_NAME_LEN - 1);
+		queue->s.name[ODP_QUEUE_NAME_LEN - 1] = 0;
+	}
+	memcpy(&queue->s.param, param, sizeof(odp_queue_param_t));
+	if (queue->s.param.sched.lock_count > sched_fn->max_ordered_locks())
+		return -1;
+
+	if (param->type == ODP_QUEUE_TYPE_SCHED) {
+		eventdev_queue_t event_queue;
+		uint8_t queue_id;
+
+		queue->s.param.deq_mode = ODP_QUEUE_OP_DISABLED;
+
+		odp_ticketlock_lock(&eventdev_gbl->lock);
+
+		if (alloc_event_queue(param->sched.sync, &event_queue)) {
+			odp_ticketlock_unlock(&eventdev_gbl->lock);
+			return -1;
+		}
+		queue_id = event_queue.id;
+		eventdev_gbl->queue_id_to_queue[queue_id] = queue->s.handle;
+		queue->s.event_queue = event_queue;
+
+		odp_ticketlock_unlock(&eventdev_gbl->lock);
+	}
+
+	queue->s.type = queue->s.param.type;
+
+	queue->s.enqueue = queue_int_enq;
+	queue->s.dequeue = queue_int_deq;
+	queue->s.enqueue_multi = queue_int_enq_multi;
+	queue->s.dequeue_multi = queue_int_deq_multi;
+
+	queue->s.pktin = PKTIN_INVALID;
+	queue->s.pktout = PKTOUT_INVALID;
+
+	if (param->type == ODP_QUEUE_TYPE_SCHED)
+		return 0;
+
+	/* Use default size for all small queues to guarantee performance
+	 * level. */
+	queue_size = eventdev_gbl->plain_config.default_queue_size;
+	if (param->size > eventdev_gbl->plain_config.default_queue_size)
+		queue_size = param->size;
+
+	/* Round up if not already a power of two */
+	queue_size = ROUNDUP_POWER2_U32(queue_size);
+
+	if (queue_size > eventdev_gbl->plain_config.max_queue_size) {
+		ODP_ERR("Too large queue size %u\n", queue_size);
+		return -1;
+	}
+	queue->s.ring_st = ring_st_create(queue->s.name, queue_size);
+	if (queue->s.ring_st == NULL)
+		return -1;
+
+	return 0;
+}
+
+static void queue_param_init(odp_queue_param_t *params)
+{
+	memset(params, 0, sizeof(odp_queue_param_t));
+	params->type = ODP_QUEUE_TYPE_PLAIN;
+	params->enq_mode = ODP_QUEUE_OP_MT;
+	params->deq_mode = ODP_QUEUE_OP_MT;
+	params->nonblocking = ODP_BLOCKING;
+	params->sched.prio  = ODP_SCHED_PRIO_DEFAULT;
+	params->sched.sync  = ODP_SCHED_SYNC_PARALLEL;
+	params->sched.group = ODP_SCHED_GROUP_ALL;
+}
+
+static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
+{
+	uint32_t queue_id;
+	queue_entry_t *queue;
+	int status;
+
+	if (odp_unlikely(info == NULL)) {
+		ODP_ERR("Unable to store info, NULL ptr given\n");
+		return -1;
+	}
+
+	queue_id = queue_to_index(handle);
+
+	if (odp_unlikely(queue_id >= ODP_CONFIG_QUEUES)) {
+		ODP_ERR("Invalid queue handle:%" PRIu64 "\n",
+			odp_queue_to_u64(handle));
+		return -1;
+	}
+
+	queue = get_qentry(queue_id);
+
+	LOCK(queue);
+	status = queue->s.status;
+
+	if (odp_unlikely(status == QUEUE_STATUS_FREE)) {
+		UNLOCK(queue);
+		ODP_ERR("Invalid queue status:%d\n", status);
+		return -1;
+	}
+
+	info->name = queue->s.name;
+	info->param = queue->s.param;
+
+	UNLOCK(queue);
+
+	return 0;
+}
+
+static uint64_t queue_to_u64(odp_queue_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+static odp_pktout_queue_t queue_get_pktout(queue_t q_int)
+{
+	return qentry_from_int(q_int)->s.pktout;
+}
+
+static void queue_set_pktout(queue_t q_int, odp_pktio_t pktio, int index)
+{
+	queue_entry_t *qentry = qentry_from_int(q_int);
+
+	qentry->s.pktout.pktio = pktio;
+	qentry->s.pktout.index = index;
+}
+
+static odp_pktin_queue_t queue_get_pktin(queue_t q_int)
+{
+	return qentry_from_int(q_int)->s.pktin;
+}
+
+static void queue_set_pktin(queue_t q_int, odp_pktio_t pktio, int index)
+{
+	queue_entry_t *qentry = qentry_from_int(q_int);
+
+	qentry->s.pktin.pktio = pktio;
+	qentry->s.pktin.index = index;
+}
+
+static void queue_set_enq_deq_func(queue_t q_int,
+				   queue_enq_fn_t enq,
+				   queue_enq_multi_fn_t enq_multi,
+				   queue_deq_fn_t deq,
+				   queue_deq_multi_fn_t deq_multi)
+{
+	queue_entry_t *qentry = qentry_from_int(q_int);
+
+	LOCK(qentry);
+
+	if (enq)
+		qentry->s.enqueue = enq;
+
+	if (enq_multi)
+		qentry->s.enqueue_multi = enq_multi;
+
+	if (deq)
+		qentry->s.dequeue = deq;
+
+	if (deq_multi)
+		qentry->s.dequeue_multi = deq_multi;
+
+	UNLOCK(qentry);
+}
+
+static queue_t queue_from_ext(odp_queue_t handle)
+{
+	return qentry_to_int(handle_to_qentry(handle));
+}
+
+static odp_queue_t queue_to_ext(queue_t q_int)
+{
+	return qentry_from_int(q_int)->s.handle;
+}
+
+/* API functions */
+queue_api_t queue_eventdev_api = {
+	.queue_create = queue_create,
+	.queue_destroy = queue_destroy,
+	.queue_lookup = queue_lookup,
+	.queue_capability = queue_capability,
+	.queue_context_set = queue_context_set,
+	.queue_context = queue_context,
+	.queue_enq = queue_enq,
+	.queue_enq_multi = queue_enq_multi,
+	.queue_deq = queue_deq,
+	.queue_deq_multi = queue_deq_multi,
+	.queue_type = queue_type,
+	.queue_sched_type = queue_sched_type,
+	.queue_sched_prio = queue_sched_prio,
+	.queue_sched_group = queue_sched_group,
+	.queue_lock_count = queue_lock_count,
+	.queue_to_u64 = queue_to_u64,
+	.queue_param_init = queue_param_init,
+	.queue_info = queue_info
+};
+
+/* Functions towards internal components */
+queue_fn_t queue_eventdev_fn = {
+	.init_global = queue_init_global,
+	.term_global = queue_term_global,
+	.init_local = queue_init_local,
+	.term_local = queue_term_local,
+	.from_ext = queue_from_ext,
+	.to_ext = queue_to_ext,
+	.enq = queue_int_enq,
+	.enq_multi = queue_int_enq_multi,
+	.deq = queue_int_deq,
+	.deq_multi = queue_int_deq_multi,
+	.get_pktout = queue_get_pktout,
+	.set_pktout = queue_set_pktout,
+	.get_pktin = queue_get_pktin,
+	.set_pktin = queue_set_pktin,
+	.set_enq_deq_fn = queue_set_enq_deq_func
+};

--- a/platform/linux-dpdk/odp_queue_if.c
+++ b/platform/linux-dpdk/odp_queue_if.c
@@ -16,6 +16,9 @@
 extern const queue_api_t queue_basic_api;
 extern const queue_fn_t queue_basic_fn;
 
+extern const queue_api_t queue_eventdev_api;
+extern const queue_fn_t queue_eventdev_fn;
+
 const queue_api_t *queue_api;
 const queue_fn_t *queue_fn;
 
@@ -121,6 +124,9 @@ int _odp_queue_init_global(void)
 	    !strcmp(sched, "iquery")) {
 		queue_fn = &queue_basic_fn;
 		queue_api = &queue_basic_api;
+	} else if (!strcmp(sched, "eventdev")) {
+		queue_fn = &queue_eventdev_fn;
+		queue_api = &queue_eventdev_api;
 	} else {
 		ODP_ABORT("Unknown scheduler specified via ODP_SCHEDULER\n");
 		return -1;

--- a/platform/linux-dpdk/odp_schedule_eventdev.c
+++ b/platform/linux-dpdk/odp_schedule_eventdev.c
@@ -1,0 +1,914 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odp/api/shared_memory.h>
+#include <odp/api/ticketlock.h>
+#include <odp_debug_internal.h>
+#include <odp_schedule_if.h>
+#include <odp_config_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_eventdev_internal.h>
+#include <odp/api/thrmask.h>
+#include <odp_timer_internal.h>
+
+#include <inttypes.h>
+#include <string.h>
+
+#include <rte_config.h>
+#include <rte_ethdev.h>
+#include <rte_eventdev.h>
+#include <rte_event_eth_rx_adapter.h>
+#include <rte_service.h>
+
+/* Start of named groups in group mask arrays */
+#define SCHED_GROUP_NAMED (ODP_SCHED_GROUP_CONTROL + 1)
+
+/* Number of scheduling groups */
+#define NUM_SCHED_GRPS 32
+
+static inline odp_pktio_t index_to_pktio(int pktio_index)
+{
+	return (odp_pktio_t)(uintptr_t)pktio_index + 1;
+}
+
+static inline odp_queue_t queue_id_to_queue(uint8_t queue_id)
+{
+	return eventdev_gbl->queue_id_to_queue[queue_id];
+}
+
+static int link_port(uint8_t dev_id, uint8_t port_id, uint8_t queue_ids[],
+		     uint8_t priorities[], uint16_t nb_links, uint8_t link_now)
+{
+	int ret;
+
+	odp_spinlock_lock(&eventdev_gbl->port[port_id].lock);
+
+	if (!eventdev_gbl->port[port_id].linked && !link_now) {
+		odp_spinlock_unlock(&eventdev_gbl->port[port_id].lock);
+		return 0;
+	}
+
+	ret = rte_event_port_link(dev_id, port_id, queue_ids, priorities,
+				  nb_links);
+	if (ret < 0 || (queue_ids && ret != nb_links)) {
+		ODP_ERR("rte_event_port_link failed: %d\n", ret);
+		odp_spinlock_unlock(&eventdev_gbl->port[port_id].lock);
+		return ret;
+	}
+
+	eventdev_gbl->port[port_id].linked = 1;
+
+	odp_spinlock_unlock(&eventdev_gbl->port[port_id].lock);
+
+	return ret;
+}
+
+static int unlink_port(uint8_t dev_id, uint8_t port_id, uint8_t queue_ids[],
+		       uint16_t nb_links)
+{
+	int ret;
+
+	odp_spinlock_lock(&eventdev_gbl->port[port_id].lock);
+
+	if (!eventdev_gbl->port[port_id].linked) {
+		odp_spinlock_unlock(&eventdev_gbl->port[port_id].lock);
+		return 0;
+	}
+
+	ret = rte_event_port_unlink(dev_id, port_id, queue_ids, nb_links);
+	if (ret < 0) {
+		ODP_ERR("rte_event_port_unlink failed: %d\n", ret);
+		odp_spinlock_unlock(&eventdev_gbl->port[port_id].lock);
+		return ret;
+	}
+
+	if (queue_ids == NULL)
+		eventdev_gbl->port[port_id].linked = 0;
+
+	odp_spinlock_unlock(&eventdev_gbl->port[port_id].lock);
+
+	return ret;
+}
+
+int resume_scheduling(uint8_t dev_id, uint8_t port_id)
+{
+	uint8_t queue_ids[MAX_EVENT_QUEUES];
+	uint8_t priorities[MAX_EVENT_QUEUES];
+	int nb_links = 0;
+	int ret;
+	int i;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	for (i = 0; i < NUM_SCHED_GRPS; i++) {
+		int j;
+
+		if (!eventdev_gbl->grp[i].allocated ||
+		    !odp_thrmask_isset(&eventdev_gbl->grp[i].mask,
+				       eventdev_local.thr))
+			continue;
+
+		for (j = 0; j < MAX_EVENT_QUEUES; j++) {
+			queue_entry_t *queue = eventdev_gbl->grp[i].queue[j];
+
+			if (!queue)
+				continue;
+
+			queue_ids[nb_links] = queue->s.event_queue.id;
+			priorities[nb_links] = queue->s.param.sched.prio;
+			nb_links++;
+		}
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+
+	if (!nb_links)
+		return 0;
+
+	ret = link_port(dev_id, port_id, queue_ids, priorities, nb_links, 1);
+	if (ret != nb_links)
+		return -1;
+
+	if (eventdev_local.started == 0) {
+		odp_atomic_inc_u32(&eventdev_gbl->num_started);
+		eventdev_local.started = 1;
+	}
+
+	return 0;
+}
+
+static int link_group(int group, const odp_thrmask_t *mask, odp_bool_t unlink)
+{
+	odp_thrmask_t new_mask;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t queue_ids[MAX_EVENT_QUEUES];
+	uint8_t priorities[MAX_EVENT_QUEUES];
+	int nb_links = 0;
+	int ret;
+	int thr;
+	int i;
+
+	for (i = 0; i < MAX_EVENT_QUEUES; i++) {
+		queue_entry_t *queue = eventdev_gbl->grp[group].queue[i];
+
+		if (queue == NULL)
+			continue;
+
+		queue_ids[nb_links] = queue->s.event_queue.id;
+		priorities[nb_links] = queue->s.param.sched.prio;
+		nb_links++;
+	}
+
+	new_mask = *mask;
+	thr = odp_thrmask_first(&new_mask);
+	while (thr >= 0) {
+		uint8_t port_id = thr;
+
+		thr = odp_thrmask_next(&new_mask, thr);
+
+		if (unlink)
+			ret = unlink_port(dev_id, port_id, queue_ids, nb_links);
+		else
+			ret = link_port(dev_id, port_id, queue_ids, priorities,
+					nb_links, 0);
+		if (ret < 0) {
+			ODP_ERR("Modifying port links failed\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static int rx_adapter_create(uint8_t dev_id, uint8_t rx_adapter_id,
+			     const struct rte_event_dev_config *config)
+{
+	struct rte_event_port_conf port_config;
+	uint32_t capa;
+	int ret;
+
+	ret = rte_event_eth_rx_adapter_caps_get(dev_id, rx_adapter_id, &capa);
+	if (ret) {
+		ODP_ERR("rte_event_eth_rx_adapter_caps_get failed: %d\n", ret);
+		return -1;
+	}
+	if ((capa & RTE_EVENT_ETH_RX_ADAPTER_CAP_MULTI_EVENTQ) == 0)
+		eventdev_gbl->rx_adapter.single_queue = 1;
+
+	port_config.new_event_threshold = config->nb_events_limit;
+	port_config.dequeue_depth = config->nb_event_port_dequeue_depth;
+	port_config.enqueue_depth = config->nb_event_port_enqueue_depth;
+	ret = rte_event_eth_rx_adapter_create(rx_adapter_id, dev_id,
+					      &port_config);
+	if (ret) {
+		ODP_ERR("rte_event_eth_rx_adapter_create failed: %d\n", ret);
+		return -1;
+	}
+
+	eventdev_gbl->rx_adapter.status = RX_ADAPTER_STOPPED;
+
+	return 0;
+}
+
+static int rx_adapter_add_queues(uint8_t rx_adapter_id, uint8_t port_id,
+				 int num_pktin, int pktin_idx[],
+				 odp_queue_t queues[])
+{
+	int ret = 0;
+	int i;
+
+	/* SW eventdev requires that all queues have ports linked */
+	link_all_queues(eventdev_gbl->dev_id, &eventdev_gbl->config);
+
+	for (i = 0; i < num_pktin; i++) {
+		queue_entry_t *queue = handle_to_qentry(queues[i]);
+		struct rte_event_eth_rx_adapter_queue_conf qconf;
+		struct rte_event ev;
+		int32_t rx_queue_id = pktin_idx[i];
+
+		ev.queue_id = queue->s.event_queue.id;
+		ev.flow_id = 0;
+		ev.sched_type =  queue->s.param.sched.prio;
+		ev.sched_type =  event_schedule_type(queue->s.param.sched.sync);
+		ev.priority = 0;
+
+		qconf.ev = ev;
+		qconf.rx_queue_flags = 0;
+		qconf.servicing_weight = 1;
+
+		if (eventdev_gbl->rx_adapter.single_queue)
+			rx_queue_id = -1;
+
+		ret = rte_event_eth_rx_adapter_queue_add(rx_adapter_id, port_id,
+							 rx_queue_id, &qconf);
+		if (ret) {
+			ODP_ERR("rte_event_eth_rx_adapter_queue_add failed\n");
+			return -1;
+		}
+
+		if (eventdev_gbl->rx_adapter.single_queue)
+			break;
+	}
+
+	unlink_all_queues(eventdev_gbl->dev_id, &eventdev_gbl->config);
+
+	return ret;
+}
+
+int rx_adapter_close(void)
+{
+	uint16_t port_id;
+	uint8_t rx_adapter_id = eventdev_gbl->rx_adapter.id;
+	int ret = 0;
+
+	if (eventdev_gbl->rx_adapter.status == RX_ADAPTER_INIT)
+		return ret;
+
+	if (eventdev_gbl->rx_adapter.status != RX_ADAPTER_STOPPED &&
+	    rte_event_eth_rx_adapter_stop(rx_adapter_id)) {
+		ODP_ERR("Failed to stop RX adapter\n");
+		ret = -1;
+	}
+
+	RTE_ETH_FOREACH_DEV(port_id) {
+		rte_eth_dev_close(port_id);
+	}
+
+	eventdev_gbl->rx_adapter.status = RX_ADAPTER_INIT;
+
+	return ret;
+}
+
+void rx_adapter_port_stop(uint16_t port_id)
+{
+	uint8_t rx_adapter_id = eventdev_gbl->rx_adapter.id;
+
+	if (rte_event_eth_rx_adapter_queue_del(rx_adapter_id, port_id, -1))
+		ODP_ERR("Failed to delete RX queue\n");
+
+	rte_eth_dev_stop(port_id);
+}
+
+static int init_global(void)
+{
+	ODP_DBG("Using eventdev scheduler\n");
+	return 0;
+}
+
+static int init_local(void)
+{
+	return 0;
+}
+
+static int term_local(void)
+{
+	return 0;
+}
+
+static int term_global(void)
+{
+	return 0;
+}
+
+static uint32_t max_ordered_locks(void)
+{
+	return 0;
+}
+
+static int init_queue(uint32_t qi, const odp_schedule_param_t *sched_param)
+{
+	queue_entry_t *queue = get_qentry(qi);
+	odp_thrmask_t mask;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t queue_id = queue->s.event_queue.id;
+	uint8_t priority = sched_param->prio;
+	int thr;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	eventdev_gbl->grp[sched_param->group].queue[queue_id] = queue;
+
+	mask = eventdev_gbl->grp[sched_param->group].mask;
+	thr = odp_thrmask_first(&mask);
+	while (0 <= thr) {
+		link_port(dev_id, thr, &queue_id, &priority, 1, 0);
+		thr = odp_thrmask_next(&mask, thr);
+	}
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+
+	return 0;
+}
+
+static void destroy_queue(uint32_t qi)
+{
+	queue_entry_t *queue = get_qentry(qi);
+	odp_thrmask_t mask;
+	odp_schedule_group_t group = queue->s.param.sched.group;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t queue_id = queue->s.event_queue.id;
+	int thr;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	eventdev_gbl->grp[group].queue[queue_id] = NULL;
+
+	mask = eventdev_gbl->grp[group].mask;
+	thr = odp_thrmask_first(&mask);
+	while (0 <= thr) {
+		unlink_port(dev_id, thr, &queue_id, 1);
+		thr = odp_thrmask_next(&mask, thr);
+	}
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+}
+
+static void pktio_start(int pktio_index, int num_pktin, int pktin_idx[],
+			odp_queue_t queue[])
+{
+	pktio_entry_t *entry = get_pktio_entry(index_to_pktio(pktio_index));
+	uint16_t port_id = entry->s.pkt_dpdk.port_id;
+	uint8_t rx_adapter_id = eventdev_gbl->rx_adapter.id;
+
+	/* All eventdev pktio devices have to be started before calling
+	 * odp_schedule()/odp_queue_enq(). This is due to the SW eventdev
+	 * requirement that all event queues are linked when
+	 * rte_event_eth_rx_adapter_queue_add() is called. */
+	if (odp_atomic_load_u32(&eventdev_gbl->num_started))
+		ODP_ABORT("All ODP pktio devices used by the scheduler have to "
+			  "be started before calling odp_schedule()/"
+			  "odp_queue_enq() for the first time.\n");
+
+	eventdev_gbl->pktio[entry->s.pkt_dpdk.port_id] = entry;
+
+	odp_spinlock_lock(&eventdev_gbl->rx_adapter.lock);
+
+	if (eventdev_gbl->rx_adapter.status == RX_ADAPTER_INIT &&
+	    rx_adapter_create(eventdev_gbl->dev_id, rx_adapter_id,
+			      &eventdev_gbl->config))
+		ODP_ABORT("Creating eventdev RX adapter failed\n");
+
+	if (rx_adapter_add_queues(rx_adapter_id, port_id, num_pktin, pktin_idx,
+				  queue))
+		ODP_ABORT("Adding RX adapter queues failed\n");
+
+	if (eventdev_gbl->rx_adapter.status == RX_ADAPTER_STOPPED) {
+		uint32_t service_id = 0;
+		int ret;
+
+		ret = rte_event_eth_rx_adapter_service_id_get(rx_adapter_id,
+							      &service_id);
+		if (ret && ret != -ESRCH) {
+			ODP_ABORT("Unable to retrieve service ID\n");
+		} else if (!ret) {
+			if (service_setup(service_id))
+				ODP_ABORT("Unable to start RX service\n");
+		}
+
+		if (rte_event_eth_rx_adapter_start(rx_adapter_id))
+			ODP_ABORT("Unable to start RX adapter\n");
+
+		eventdev_gbl->rx_adapter.status = RX_ADAPTER_RUNNING;
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->rx_adapter.lock);
+}
+
+static odp_event_t mbuf_to_event(struct rte_mbuf *mbuf)
+{
+	return (odp_event_t)mbuf;
+}
+
+static inline uint16_t event_input(struct rte_event ev[], odp_event_t out_ev[],
+				   uint16_t nb_events, odp_queue_t *out_queue)
+{
+	struct rte_mbuf *pkt_table[nb_events];
+	uint16_t num_pkts = 0;
+	uint16_t num_events = 0;
+	uint16_t i;
+	uint8_t first_queue = ev[0].queue_id;
+
+	for (i = 0; i < nb_events;  i++) {
+		struct rte_event *event = &ev[i];
+
+		if (odp_unlikely(event->queue_id != first_queue)) {
+			uint16_t cache_idx, j;
+
+			eventdev_local.cache.idx = 0;
+			for (j = i; j < nb_events; j++) {
+				cache_idx = eventdev_local.cache.count;
+				eventdev_local.cache.event[cache_idx] = ev[j];
+				eventdev_local.cache.count++;
+			}
+			break;
+		}
+
+		/* Packets have to be initialized */
+		if (event->event_type == RTE_EVENT_TYPE_ETH_RX_ADAPTER) {
+			pkt_table[num_pkts++] = event->mbuf;
+			continue;
+		}
+
+		out_ev[num_events++] = mbuf_to_event(event->mbuf);
+	}
+
+	if (num_pkts) {
+		pktio_entry_t *entry = eventdev_gbl->pktio[pkt_table[0]->port];
+
+		num_pkts = input_pkts(entry, (odp_packet_t *)pkt_table,
+				      num_pkts);
+
+		for (i = 0; i < num_pkts; i++)
+			out_ev[num_events++] = mbuf_to_event(pkt_table[i]);
+	}
+
+	if (out_queue && num_events)
+		*out_queue = queue_id_to_queue(first_queue);
+
+	return num_events;
+}
+
+/* Fetch consecutive events from the same queue from cache */
+static inline uint16_t input_cached(odp_event_t out_ev[], unsigned int max_num,
+				    odp_queue_t *out_queue)
+{
+	struct rte_event ev[max_num];
+	uint16_t idx = eventdev_local.cache.idx;
+	uint16_t i;
+	uint8_t first_queue = eventdev_local.cache.event[idx].queue_id;
+
+	for (i = 0; i < max_num && eventdev_local.cache.count; i++) {
+		uint16_t idx = eventdev_local.cache.idx;
+		struct rte_event *event = &eventdev_local.cache.event[idx];
+
+		if (odp_unlikely(event->queue_id != first_queue))
+			break;
+
+		eventdev_local.cache.idx++;
+		eventdev_local.cache.count--;
+		ev[i] = *event;
+	}
+
+	return event_input(ev, out_ev, i, out_queue);
+}
+
+static inline int schedule_loop(odp_queue_t *out_queue, uint64_t wait,
+				odp_event_t out_ev[], unsigned int max_num)
+{
+	odp_time_t next, wtime;
+	struct rte_event ev[max_num];
+	int first = 1;
+	uint16_t num_deq;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t port_id = eventdev_local.thr;
+
+	if (odp_unlikely(port_id >= eventdev_gbl->num_event_ports)) {
+		ODP_ERR("Max %" PRIu8 " scheduled workers supported\n",
+			eventdev_gbl->num_event_ports);
+		return 0;
+	}
+
+	/* Check that port is linked */
+	if (odp_unlikely(!eventdev_gbl->port[port_id].linked &&
+			 !eventdev_local.paused)) {
+		if (resume_scheduling(dev_id, port_id))
+			return 0;
+	}
+
+	if (odp_unlikely(max_num > MAX_SCHED_BURST))
+		max_num = MAX_SCHED_BURST;
+
+	if (odp_unlikely(eventdev_local.cache.count)) {
+		num_deq = input_cached(out_ev, max_num, out_queue);
+	} else {
+		while (1) {
+			timer_run();
+
+			num_deq = rte_event_dequeue_burst(dev_id, port_id, ev,
+							  max_num, 0);
+			if (num_deq) {
+				num_deq = event_input(ev, out_ev, num_deq,
+						      out_queue);
+				break;
+			}
+
+			if (wait == ODP_SCHED_WAIT)
+				continue;
+
+			if (wait == ODP_SCHED_NO_WAIT)
+				return 0;
+
+			if (first) {
+				wtime = odp_time_local_from_ns(wait);
+				next = odp_time_sum(odp_time_local(), wtime);
+				first = 0;
+				continue;
+			}
+
+			if (odp_time_cmp(next, odp_time_local()) < 0)
+				return 0;
+		}
+	}
+
+	return num_deq;
+}
+
+static odp_event_t schedule(odp_queue_t *out_queue, uint64_t wait)
+{
+	odp_event_t ev;
+
+	ev = ODP_EVENT_INVALID;
+
+	schedule_loop(out_queue, wait, &ev, 1);
+
+	return ev;
+}
+
+static int schedule_multi(odp_queue_t *out_queue, uint64_t wait,
+			  odp_event_t events[], int num)
+{
+	return schedule_loop(out_queue, wait, events, num);
+}
+
+static void schedule_pause(void)
+{
+	if (unlink_port(eventdev_gbl->dev_id, eventdev_local.thr, NULL, 0) < 0)
+		ODP_ERR("Unable to pause scheduling\n");
+
+	eventdev_local.paused = 1;
+}
+
+static void schedule_resume(void)
+{
+	if (resume_scheduling(eventdev_gbl->dev_id, eventdev_local.thr))
+		ODP_ERR("Unable to resume scheduling\n");
+
+	eventdev_local.paused = 0;
+}
+
+static void schedule_release_atomic(void)
+{
+}
+
+static void schedule_release_ordered(void)
+{
+}
+
+static uint64_t schedule_wait_time(uint64_t ns)
+{
+	return ns;
+}
+
+static inline void grp_update_mask(int grp, const odp_thrmask_t *new_mask)
+{
+	odp_thrmask_copy(&eventdev_gbl->grp[grp].mask, new_mask);
+}
+
+static int schedule_thr_add(odp_schedule_group_t group, int thr)
+{
+	odp_thrmask_t mask;
+	odp_thrmask_t new_mask;
+
+	if (group < 0 || group >= SCHED_GROUP_NAMED)
+		return -1;
+
+	odp_thrmask_zero(&mask);
+	odp_thrmask_set(&mask, thr);
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	odp_thrmask_or(&new_mask, &eventdev_gbl->grp[group].mask, &mask);
+	grp_update_mask(group, &new_mask);
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+
+	return 0;
+}
+
+static int schedule_thr_rem(odp_schedule_group_t group, int thr)
+{
+	odp_thrmask_t mask;
+	odp_thrmask_t new_mask;
+
+	if (group < 0 || group >= SCHED_GROUP_NAMED)
+		return -1;
+
+	odp_thrmask_zero(&mask);
+	odp_thrmask_set(&mask, thr);
+	odp_thrmask_xor(&new_mask, &mask, &eventdev_gbl->mask_all);
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	odp_thrmask_and(&new_mask, &eventdev_gbl->grp[group].mask,
+			&new_mask);
+	grp_update_mask(group, &new_mask);
+
+	unlink_port(eventdev_gbl->dev_id, thr, NULL, 0);
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+
+	return 0;
+}
+
+/* This function is a no-op */
+static void schedule_prefetch(int num ODP_UNUSED)
+{
+}
+
+static int schedule_num_prio(void)
+{
+	return eventdev_gbl->num_prio;
+}
+
+static int schedule_num_grps(void)
+{
+	return NUM_SCHED_GRPS;
+}
+
+static odp_schedule_group_t schedule_group_create(const char *name,
+						  const odp_thrmask_t *mask)
+{
+	odp_schedule_group_t group = ODP_SCHED_GROUP_INVALID;
+	int i;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	for (i = SCHED_GROUP_NAMED; i < NUM_SCHED_GRPS; i++) {
+		if (!eventdev_gbl->grp[i].allocated) {
+			char *grp_name = eventdev_gbl->grp[i].name;
+
+			if (name == NULL) {
+				grp_name[0] = 0;
+			} else {
+				strncpy(grp_name, name,
+					ODP_SCHED_GROUP_NAME_LEN - 1);
+				grp_name[ODP_SCHED_GROUP_NAME_LEN - 1] = 0;
+			}
+
+			grp_update_mask(i, mask);
+			group = (odp_schedule_group_t)i;
+			eventdev_gbl->grp[i].allocated = 1;
+			break;
+		}
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+	return group;
+}
+
+static int schedule_group_destroy(odp_schedule_group_t group)
+{
+	odp_thrmask_t zero;
+	int ret;
+
+	odp_thrmask_zero(&zero);
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		grp_update_mask(group, &zero);
+		memset(eventdev_gbl->grp[group].name, 0,
+		       ODP_SCHED_GROUP_NAME_LEN);
+		eventdev_gbl->grp[group].allocated = 0;
+		ret = 0;
+	} else {
+		ret = -1;
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static odp_schedule_group_t schedule_group_lookup(const char *name)
+{
+	odp_schedule_group_t group = ODP_SCHED_GROUP_INVALID;
+	int i;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	for (i = SCHED_GROUP_NAMED; i < NUM_SCHED_GRPS; i++) {
+		if (strcmp(name, eventdev_gbl->grp[i].name) == 0) {
+			group = (odp_schedule_group_t)i;
+			break;
+		}
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+	return group;
+}
+
+static int schedule_group_join(odp_schedule_group_t group,
+			       const odp_thrmask_t *mask)
+{
+	int ret = 0;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		odp_thrmask_t new_mask;
+		odp_thrmask_t link_mask;
+
+		odp_thrmask_and(&link_mask, &eventdev_gbl->grp[group].mask,
+				mask);
+		odp_thrmask_xor(&link_mask, &link_mask, mask);
+		odp_thrmask_or(&new_mask, &eventdev_gbl->grp[group].mask,
+			       mask);
+		grp_update_mask(group, &new_mask);
+
+		ret = link_group(group, &link_mask, 0);
+	} else {
+		ret = -1;
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static int schedule_group_leave(odp_schedule_group_t group,
+				const odp_thrmask_t *mask)
+{
+	odp_thrmask_t new_mask;
+	odp_thrmask_t unlink_mask;
+	int ret = 0;
+
+	odp_thrmask_xor(&new_mask, mask, &eventdev_gbl->mask_all);
+	odp_thrmask_and(&unlink_mask, mask, &eventdev_gbl->mask_all);
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		odp_thrmask_and(&unlink_mask, &eventdev_gbl->grp[group].mask,
+				&unlink_mask);
+		odp_thrmask_and(&new_mask, &eventdev_gbl->grp[group].mask,
+				&new_mask);
+		grp_update_mask(group, &new_mask);
+
+		ret = link_group(group, &unlink_mask, 1);
+	} else {
+		ret = -1;
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static int schedule_group_thrmask(odp_schedule_group_t group,
+				  odp_thrmask_t *thrmask)
+{
+	int ret;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		*thrmask = eventdev_gbl->grp[group].mask;
+		ret = 0;
+	} else {
+		ret = -1;
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static int schedule_group_info(odp_schedule_group_t group,
+			       odp_schedule_group_info_t *info)
+{
+	int ret;
+
+	odp_spinlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		info->name    = eventdev_gbl->grp[group].name;
+		info->thrmask = eventdev_gbl->grp[group].mask;
+		ret = 0;
+	} else {
+		ret = -1;
+	}
+
+	odp_spinlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static void schedule_order_lock(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_unlock(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_unlock_lock(uint32_t unlock_index ODP_UNUSED,
+				       uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_lock_start(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_lock_wait(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void order_lock(void)
+{
+}
+
+static void order_unlock(void)
+{
+}
+
+/* Fill in scheduler interface */
+const schedule_fn_t schedule_eventdev_fn = {
+	.status_sync = 0,
+	.pktio_start = pktio_start,
+	.thr_add = schedule_thr_add,
+	.thr_rem = schedule_thr_rem,
+	.num_grps = schedule_num_grps,
+	.init_queue = init_queue,
+	.destroy_queue = destroy_queue,
+	.sched_queue = NULL,
+	.ord_enq_multi = NULL,
+	.init_global = init_global,
+	.term_global = term_global,
+	.init_local  = init_local,
+	.term_local  = term_local,
+	.order_lock = order_lock,
+	.order_unlock = order_unlock,
+	.max_ordered_locks = max_ordered_locks,
+	.unsched_queue = NULL,
+	.save_context = NULL
+};
+
+/* Fill in scheduler API calls */
+const schedule_api_t schedule_eventdev_api = {
+	.schedule_wait_time       = schedule_wait_time,
+	.schedule                 = schedule,
+	.schedule_multi           = schedule_multi,
+	.schedule_pause           = schedule_pause,
+	.schedule_resume          = schedule_resume,
+	.schedule_release_atomic  = schedule_release_atomic,
+	.schedule_release_ordered = schedule_release_ordered,
+	.schedule_prefetch        = schedule_prefetch,
+	.schedule_num_prio        = schedule_num_prio,
+	.schedule_group_create    = schedule_group_create,
+	.schedule_group_destroy   = schedule_group_destroy,
+	.schedule_group_lookup    = schedule_group_lookup,
+	.schedule_group_join      = schedule_group_join,
+	.schedule_group_leave     = schedule_group_leave,
+	.schedule_group_thrmask   = schedule_group_thrmask,
+	.schedule_group_info      = schedule_group_info,
+	.schedule_order_lock      = schedule_order_lock,
+	.schedule_order_unlock    = schedule_order_unlock,
+	.schedule_order_unlock_lock  = schedule_order_unlock_lock,
+	.schedule_order_lock_start   = schedule_order_lock_start,
+	.schedule_order_lock_wait    = schedule_order_lock_wait
+};

--- a/platform/linux-dpdk/odp_schedule_if.c
+++ b/platform/linux-dpdk/odp_schedule_if.c
@@ -22,6 +22,9 @@ extern const schedule_api_t schedule_basic_api;
 extern const schedule_fn_t schedule_iquery_fn;
 extern const schedule_api_t schedule_iquery_api;
 
+extern const schedule_fn_t schedule_eventdev_fn;
+extern const schedule_api_t schedule_eventdev_api;
+
 const schedule_fn_t *sched_fn;
 const schedule_api_t *sched_api;
 
@@ -154,6 +157,9 @@ int _odp_schedule_init_global(void)
 	} else if (!strcmp(sched, "iquery")) {
 		sched_fn = &schedule_iquery_fn;
 		sched_api = &schedule_iquery_api;
+	} else if (!strcmp(sched, "eventdev")) {
+		sched_fn = &schedule_eventdev_fn;
+		sched_api = &schedule_eventdev_api;
 	} else {
 		ODP_ABORT("Unknown scheduler specified via ODP_SCHEDULER\n");
 		return -1;

--- a/platform/linux-dpdk/odp_thread.c
+++ b/platform/linux-dpdk/odp_thread.c
@@ -139,7 +139,6 @@ int odp_thread_init_local(odp_thread_type_t type)
 {
 	int id;
 	int cpu;
-	struct rte_config *cfg = rte_eal_get_configuration();
 
 	odp_spinlock_lock(&thread_globals->lock);
 	id = alloc_id(type);
@@ -161,9 +160,6 @@ int odp_thread_init_local(odp_thread_type_t type)
 	thread_globals->thr[id].cpu  = cpu;
 	thread_globals->thr[id].type = type;
 	RTE_PER_LCORE(_lcore_id) = cpu;
-	if (cfg->lcore_role[cpu] == ROLE_RTE)
-		ODP_ERR("There is a thread already running on core %d\n", cpu);
-	cfg->lcore_role[cpu] = ROLE_RTE;
 
 	_odp_this_thread = &thread_globals->thr[id];
 

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -122,7 +122,6 @@ static void queue_test_capa(void)
 	CU_ASSERT(odp_queue_capability(&capa) == 0);
 
 	CU_ASSERT(capa.max_queues != 0);
-	CU_ASSERT(capa.max_ordered_locks != 0);
 	CU_ASSERT(capa.max_sched_groups != 0);
 	CU_ASSERT(capa.sched_prios != 0);
 	CU_ASSERT(capa.plain.max_num != 0);
@@ -430,10 +429,9 @@ static void queue_test_info(void)
 	param.sched.prio = ODP_SCHED_PRIO_NORMAL;
 	param.sched.sync = ODP_SCHED_SYNC_ORDERED;
 	param.sched.group = ODP_SCHED_GROUP_ALL;
-	if (capability.max_ordered_locks)
-		param.sched.lock_count = 1;
-	else
-		param.sched.lock_count = 0;
+	param.sched.lock_count = capability.max_ordered_locks;
+	if (param.sched.lock_count == 0)
+		printf("\n    Ordered locks NOT supported\n");
 	param.context = q_order_ctx;
 	q_order = odp_queue_create(nq_order, &param);
 	CU_ASSERT(ODP_QUEUE_INVALID != q_order);
@@ -459,7 +457,7 @@ static void queue_test_info(void)
 	CU_ASSERT(info.param.sched.sync == odp_queue_sched_type(q_order));
 	CU_ASSERT(info.param.sched.group == odp_queue_sched_group(q_order));
 	ret = odp_queue_lock_count(q_order);
-	CU_ASSERT(ret > 0);
+	CU_ASSERT(ret == param.sched.lock_count);
 	lock_count = ret;
 	CU_ASSERT(info.param.sched.lock_count == lock_count);
 


### PR DESCRIPTION
Initial draft implementation of ODP scheduler and queues using DPDK event device library

- Current implementation won't pass validation tests as there are still some bugs in event device library itself (rte_event_port_unlink: https://dpdk.org/tracker/show_bug.cgi?id=60)
- SW eventdev requires a separate service core
- odp_l2fwd and odp_scheduling (single core only) applications can be used to test the implementation
E.g.
`sudo ODP_SCHEDULER="eventdev" ODP_PLATFORM_PARAMS="--vdev event_sw0 -s 0x2" ./odp_scheduling -c 1`
`sudo ODP_SCHEDULER="eventdev" ODP_PLATFORM_PARAMS="--vdev event_sw0 -s 0x2" ./odp_l2fwd -m 2 -i 0,1 -c 4`

 - Since validation tests have not yet been run, there will be bugs...

V2:
- Added runtime configuration options for the number of atomic, parallel and ordered queues
- Scheduler validation test improvements
- Misc fixes (Bill)

V3:
- Timer fix (Bogdan)
- Rebased test fixes
- Added README.DPDK chapter

ToDo
- [ ] Lock free queues
- [ ] Travis testing