### PR TITLE
[PATCH v1] linux-dpdk: byteorder: implement using dpdk functions

### DIFF
--- a/platform/linux-dpdk/include/odp/api/plat/byteorder_inlines.h
+++ b/platform/linux-dpdk/include/odp/api/plat/byteorder_inlines.h
@@ -1,1 +1,114 @@
-../../../../../linux-generic/include/odp/api/plat/byteorder_inlines.h
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP byteorder
+ */
+
+#ifndef ODP_PLAT_BYTEORDER_INLINES_H_
+#define ODP_PLAT_BYTEORDER_INLINES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <rte_config.h>
+#include <rte_byteorder.h>
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef __odp_force
+#define __odp_force
+#endif
+
+#ifndef _ODP_NO_INLINE
+	/* Inline functions by default */
+	#define _ODP_INLINE static inline
+	#define odp_be_to_cpu_16 __odp_be_to_cpu_16
+	#define odp_be_to_cpu_32 __odp_be_to_cpu_32
+	#define odp_be_to_cpu_64 __odp_be_to_cpu_64
+	#define odp_cpu_to_be_16 __odp_cpu_to_be_16
+	#define odp_cpu_to_be_32 __odp_cpu_to_be_32
+	#define odp_cpu_to_be_64 __odp_cpu_to_be_64
+	#define odp_le_to_cpu_16 __odp_le_to_cpu_16
+	#define odp_le_to_cpu_32 __odp_le_to_cpu_32
+	#define odp_le_to_cpu_64 __odp_le_to_cpu_64
+	#define odp_cpu_to_le_16 __odp_cpu_to_le_16
+	#define odp_cpu_to_le_32 __odp_cpu_to_le_32
+	#define odp_cpu_to_le_64 __odp_cpu_to_le_64
+#else
+	#define _ODP_INLINE
+#endif
+
+_ODP_INLINE uint16_t odp_be_to_cpu_16(odp_u16be_t be16)
+{
+	return rte_be_to_cpu_16((__odp_force uint16_t)be16);
+}
+
+_ODP_INLINE uint32_t odp_be_to_cpu_32(odp_u32be_t be32)
+{
+	return rte_be_to_cpu_32((__odp_force uint32_t)be32);
+}
+
+_ODP_INLINE uint64_t odp_be_to_cpu_64(odp_u64be_t be64)
+{
+	return rte_be_to_cpu_64((__odp_force uint64_t)be64);
+}
+
+_ODP_INLINE odp_u16be_t odp_cpu_to_be_16(uint16_t cpu16)
+{
+	return (__odp_force odp_u16be_t)rte_cpu_to_be_16(cpu16);
+}
+
+_ODP_INLINE odp_u32be_t odp_cpu_to_be_32(uint32_t cpu32)
+{
+	return (__odp_force odp_u32be_t)rte_cpu_to_be_32(cpu32);
+}
+
+_ODP_INLINE odp_u64be_t odp_cpu_to_be_64(uint64_t cpu64)
+{
+	return (__odp_force odp_u64be_t)rte_cpu_to_be_64(cpu64);
+}
+
+_ODP_INLINE uint16_t odp_le_to_cpu_16(odp_u16le_t le16)
+{
+	return rte_le_to_cpu_16((__odp_force uint16_t)le16);
+}
+
+_ODP_INLINE uint32_t odp_le_to_cpu_32(odp_u32le_t le32)
+{
+	return rte_le_to_cpu_32((__odp_force uint32_t)le32);
+}
+
+_ODP_INLINE uint64_t odp_le_to_cpu_64(odp_u64le_t le64)
+{
+	return rte_le_to_cpu_64((__odp_force uint64_t)le64);
+}
+
+_ODP_INLINE odp_u16le_t odp_cpu_to_le_16(uint16_t cpu16)
+{
+	return (__odp_force odp_u16le_t)rte_cpu_to_le_16(cpu16);
+}
+
+_ODP_INLINE odp_u32le_t odp_cpu_to_le_32(uint32_t cpu32)
+{
+	return (__odp_force odp_u32le_t)rte_cpu_to_le_32(cpu32);
+}
+
+_ODP_INLINE odp_u64le_t odp_cpu_to_le_64(uint64_t cpu64)
+{
+	return (__odp_force odp_u64le_t)rte_cpu_to_le_64(cpu64);
+}
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-dpdk/include/odp/api/plat/packet_inlines.h
@@ -34,6 +34,8 @@ extern "C" {
 #include <rte_config.h>
 #include <rte_mbuf.h>
 
+#include <rte_memcpy.h>
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -297,8 +299,8 @@ _ODP_INLINE void odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,
 		rte_prefetch0(addr + ofs);
 }
 
-_ODP_INLINE int odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
-				       uint32_t len, void *dst)
+static inline int _odp_packet_copy_to_mem_seg(odp_packet_t pkt, uint32_t offset,
+					      uint32_t len, void *dst)
 {
 	void *mapaddr;
 	uint32_t seglen = 0; /* GCC */
@@ -311,11 +313,25 @@ _ODP_INLINE int odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
 	while (len > 0) {
 		mapaddr = odp_packet_offset(pkt, offset, &seglen, NULL);
 		cpylen = len > seglen ? seglen : len;
-		memcpy(dstaddr, mapaddr, cpylen);
+		rte_memcpy(dstaddr, mapaddr, cpylen);
 		offset  += cpylen;
 		dstaddr += cpylen;
 		len     -= cpylen;
 	}
+
+	return 0;
+}
+
+_ODP_INLINE int odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
+				       uint32_t len, void *dst)
+{
+	uint32_t seg_len = odp_packet_seg_len(pkt);
+	uint8_t *data    = (uint8_t *)odp_packet_data(pkt);
+
+	if (odp_unlikely(offset + len > seg_len))
+		return _odp_packet_copy_to_mem_seg(pkt, offset, len, dst);
+
+	rte_memcpy(dst, data + offset, len);
 
 	return 0;
 }

--- a/platform/linux-dpdk/include/odp_packet_dpdk.h
+++ b/platform/linux-dpdk/include/odp_packet_dpdk.h
@@ -8,6 +8,7 @@
 #define ODP_PACKET_DPDK_H_
 
 #include <odp/api/packet_io.h>
+#include <odp/api/plat/packet_inlines.h>
 #include <odp_packet_internal.h>
 
 #include <stdint.h>
@@ -26,9 +27,10 @@ static inline int dpdk_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
 					  odp_pktio_parser_layer_t layer,
 					  odp_pktin_config_opt_t pktin_cfg)
 {
-	uint32_t seg_len = odp_packet_seg_len(packet_handle(pkt_hdr));
-	uint32_t len = packet_len(pkt_hdr);
-	uint8_t *base = odp_packet_data(packet_handle(pkt_hdr));
+	odp_packet_t pkt = packet_handle(pkt_hdr);
+	uint32_t seg_len = odp_packet_seg_len(pkt);
+	uint32_t len = odp_packet_len(pkt);
+	uint8_t *base = odp_packet_data(pkt);
 
 	return dpdk_packet_parse_common(&pkt_hdr->p, base, len,
 					seg_len, mbuf, layer, pktin_cfg);

--- a/platform/linux-dpdk/odp_packet.c
+++ b/platform/linux-dpdk/odp_packet.c
@@ -926,9 +926,8 @@ int _odp_packet_set_data(odp_packet_t pkt, uint32_t offset,
 	void *mapaddr;
 	uint32_t seglen = 0; /* GCC */
 	uint32_t setlen;
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	if (offset + len > packet_len(pkt_hdr))
+	if (offset + len > odp_packet_len(pkt))
 		return -1;
 
 	while (len > 0) {
@@ -952,9 +951,8 @@ int _odp_packet_cmp_data(odp_packet_t pkt, uint32_t offset,
 	uint32_t seglen = 0; /* GCC */
 	uint32_t cmplen;
 	int ret;
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	ODP_ASSERT(offset + len <= packet_len(pkt_hdr));
+	ODP_ASSERT(offset + len <= odp_packet_len(pkt));
 
 	while (len > 0) {
 		mapaddr = odp_packet_offset(pkt, offset, &seglen, NULL);
@@ -1211,7 +1209,7 @@ static uint32_t packet_sum16_32(odp_packet_hdr_t *pkt_hdr,
 {
 	uint32_t sum = 0;
 
-	if (offset + len > packet_len(pkt_hdr))
+	if (offset + len > odp_packet_len(packet_handle(pkt_hdr)))
 		return 0;
 
 	while (len > 0) {
@@ -1734,7 +1732,7 @@ static int _odp_packet_tcp_udp_chksum_insert(odp_packet_t pkt, uint16_t proto)
 	uint16_t l3_ver;
 	uint16_t chksum;
 	uint32_t chksum_offset;
-	uint32_t frame_len = packet_len(pkt_hdr);
+	uint32_t frame_len = odp_packet_len(pkt);
 
 	if (pkt_hdr->p.l3_offset == ODP_PACKET_OFFSET_INVALID)
 		return -1;
@@ -1819,7 +1817,7 @@ static int packet_l4_chksum(odp_packet_hdr_t *pkt_hdr,
 			    odp_proto_chksums_t chksums,
 			    uint32_t l4_part_sum)
 {
-	uint32_t len = packet_len(pkt_hdr);
+	uint32_t len = odp_packet_len(packet_handle(pkt_hdr));
 
 	/* UDP chksum == 0 case is covered in parse_udp() */
 	if (chksums.chksum.udp &&
@@ -1867,9 +1865,10 @@ int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
 		       odp_proto_layer_t layer,
 		       odp_proto_chksums_t chksums)
 {
-	uint32_t seg_len = odp_packet_seg_len((odp_packet_t)pkt_hdr);
-	uint32_t len = packet_len(pkt_hdr);
-	const uint8_t *base = odp_packet_data((odp_packet_t)pkt_hdr);
+	odp_packet_t pkt = packet_handle(pkt_hdr);
+	uint32_t seg_len = odp_packet_seg_len(pkt);
+	uint32_t len = odp_packet_len(pkt);
+	const uint8_t *base = odp_packet_data(pkt);
 	uint32_t offset = 0;
 	uint16_t ethtype;
 	uint32_t l4_part_sum = 0;
@@ -1903,7 +1902,7 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 	const uint8_t *data;
 	uint32_t seg_len;
-	uint32_t len = packet_len(pkt_hdr);
+	uint32_t len = odp_packet_len(pkt);
 	odp_proto_t proto = param->proto;
 	odp_proto_layer_t layer = param->last_layer;
 	int ret;


### PR DESCRIPTION
This PR includes the packet clean-up patches to enable passing validation tests. Should be rebased before merge.