### PR TITLE
linux-dpdk: decrease default tx descriptor count

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -32,7 +32,7 @@ pool: {
 pktio_dpdk: {
 	# Default options
 	num_rx_desc = 128
-	num_tx_desc = 512
+	num_tx_desc = 256
 	rx_drop_en = 0
 
 	# Driver specific options (use PMD names from DPDK)


### PR DESCRIPTION
Increases i40e driver single core l2fwd performance by over 10%.

Signed-off-by: Matias Elo <matias.elo@nokia.com>